### PR TITLE
chore: update rhiza template version to v0.10.1

### DIFF
--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v0.9.5"
+ref: "v0.10.1"
 
 templates:
   - github


### PR DESCRIPTION
## Summary

- Bumps `.rhiza/template.yml` ref from `v0.9.5` to `v0.10.1`

## Test plan

- [ ] Verify the rhiza sync workflow triggers and applies the new template version successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)