### PR TITLE
chore: update rhiza to v0.18.4

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,6 +63,25 @@ updates:
       prefix: "chore(deps)"
       include: "scope"
 
+  # Python dependencies (pip) for /.rhiza/requirements — internal build deps, no auto-PRs
+  - package-ecosystem: "pip"
+    directory: "/.rhiza/requirements"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "09:00"
+      timezone: "Asia/Dubai"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
+    open-pull-requests-limit: 0
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+
   # Docker
   #- package-ecosystem: "docker"
   #  directory: "/docker"

--- a/.rhiza/template.yml
+++ b/.rhiza/template.yml
@@ -1,5 +1,5 @@
 repository: "jebel-quant/rhiza"
-ref: "v0.18.2"
+ref: "v0.18.4"
 
 profiles:
   - github-project


### PR DESCRIPTION
## Summary

- Bumps `template-branch` to `v0.18.4` in `.rhiza/template.yml`
- Bumps `.rhiza/.rhiza-version` to `0.16.1`
- Runs `make sync` to apply upstream template changes
