### PR TITLE
Address open issues #119–#123

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,118 +1,278 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- Tighten tooling rigor: type checking, coverage gate, warnings-as-errors (#118)
+
+### Dependencies
+
+- Chore(deps)(deps): bump the github-actions group with 9 updates (#117)
+- Chore(deps-dev)(deps-dev): bump ruff in the python-dependencies group (#116)
+
 ## [0.5.1] - 2026-06-08
 
-### 💼 Other
+### Maintenance
 
-- Bump version 0.5.0 → 0.5.1
-
-### ⚙️ Miscellaneous Tasks
-
-- Update CHANGELOG.md for v0.5.0 [skip ci]
-- Update rhiza to v0.18.4 (#112)
 - Update rhiza to v0.18.8 (#115)
+- Update rhiza to v0.18.4 (#112)
+
+### Dependencies
+
+- Chore(deps)(deps): bump the github-actions group with 9 updates (#114)
+- Chore(deps)(deps): bump the github-actions group with 8 updates (#113)
+
 ## [0.5.0] - 2026-05-28
 
-### 💼 Other
+### Maintenance
 
-- Bump version 0.4.0 → 0.5.0
-
-### ⚙️ Miscellaneous Tasks
-
-- Update Rhiza template to v0.10.9 (#102)
-- Bump rhiza to v0.14.1 with github-project profile (#103)
-- Update rhiza to v0.15.2 (#106)
-- Bump rhiza to v0.15.2 (#107)
-- Update rhiza to v0.15.3 (#108)
-- Update rhiza to v0.17.0 (#109)
 - Update rhiza to v0.18.2 (#111)
+- Update rhiza to v0.17.0 (#109)
+- Update rhiza to v0.15.3 (#108)
+- Bump rhiza to v0.15.2 (#107)
+- Update rhiza to v0.15.2 (#106)
+- Bump rhiza to v0.14.1 with github-project profile (#103)
+- Update Rhiza template to v0.10.9 (#102)
+
+### Dependencies
+
+- Chore(deps-dev)(deps-dev): bump types-pyyaml (#101)
+
 ## [0.4.0] - 2026-05-19
 
-### 🐛 Bug Fixes
+### Changed
+
+- Accept `profiles` in `.rhiza/template.yml` for `check-rhiza-config` (#96)
+- Remove Guides section from mkdocs.yml (#98)
+- Update reference version to v0.10.3 (#91)
+- Update mkdocs.yml
+- Tschm patch 1 (#90)
+- Add root-level mkdocs.yml inheriting from docs/mkdocs-base.yml (#86)
+
+### Fixed
 
 - Serve coverage badge from GitHub Pages instead of gh-pages branch (#100)
-
-### 💼 Other
-
 - Ensure _book/ exists before touching .nojekyll when mkdocs.yml is absent
-- Bump version 0.3.3 → 0.4.0
 
-### 📚 Documentation
+### Documentation
 
 - Add API reference and CI/CD reports to book
 
-### ⚙️ Miscellaneous Tasks
+### Maintenance
 
-- Update rhiza template version to v0.9.5
-- Sync rhiza template v0.9.5
-- Update rhiza template version to v0.10.1 (#87)
-- Sync rhiza template to latest (#88)
 - Update Rhiza template to v0.10.7 (#97)
+- Sync rhiza template to latest (#88)
+- Update rhiza template version to v0.10.1 (#87)
+- Sync rhiza template v0.9.5
+- Update rhiza template version to v0.9.5
+- Update template.yml to reference version v0.9.4 (#84)
+
+### Dependencies
+
+- Chore(deps)(deps): bump github/codeql-action in the github-actions group (#94)
+- Chore(deps-dev)(deps-dev): bump types-pyyaml (#93)
+- Chore(deps)(deps): bump github/codeql-action in the github-actions group (#92)
+- Chore(deps)(deps): bump the github-actions group with 2 updates (#89)
+- Lock file maintenance (#83)
+- Update pre-commit hook jebel-quant/rhiza-hooks to v0.3.3 (#82)
+
 ## [0.3.3] - 2026-04-12
 
-### 💼 Other
+### Maintenance
 
-- Bump version 0.3.2 → 0.3.3
+- Update template.yml to use ref v0.9.2 (#80)
+
+### Dependencies
+
+- Chore(deps)(deps): bump docker/login-action in the github-actions group (#79)
+
 ## [0.3.2] - 2026-04-02
 
-### 💼 Other
+### Maintenance
 
-- Bump version 0.3.1 → 0.3.2
+- Update ref version to v0.8.20 and add renovate template (#78)
+
+### Dependencies
+
+- Chore(deps)(deps): bump github/codeql-action in the github-actions group (#77)
+
 ## [0.3.1] - 2026-03-22
 
-### 💼 Other
+### Changed
 
-- Bump version 0.3.0 → 0.3.1
+- Add license-files to pyproject.toml (#76)
+- [WIP] Add coverage badge pointing to gh-pages (#75)
+- Update __init__.py (#73)
+- Tschm patch 200 (#72)
+- Update .cfg.toml (#52)
+- Sync
+
+### Maintenance
+
+- Update template.yml to use ref v0.8.13 (#71)
+- Update template.yml to reference version v0.8.12 (#67)
+- Update template repository and version reference
+
+### Dependencies
+
+- Update github/codeql-action action to v4.33.0 (#65)
+- Update actions/upload-artifact action to v7 (#62)
+- Update actions/download-artifact action to v8 (#61)
+- Update docker/login-action action to v4 (#66)
+- Update astral-sh/setup-uv action to v7.3.1 (#56)
+- Update dependency jebel-quant/rhiza to v0.8.3 (#54)
+- Update pre-commit hook astral-sh/uv-pre-commit to v0.10.5 (#55)
+- Update dependency astral-sh/uv to v0.10.5 (#53)
+- Update github/codeql-action action to v4.32.4 (#51)
+- Update pre-commit hook astral-sh/ruff-pre-commit to v0.15.2 (#50)
+- Update pre-commit hook astral-sh/uv-pre-commit to v0.10.4 (#49)
+- Update dependency astral-sh/uv to v0.10.4 (#48)
+- Update dependency jebel-quant/rhiza to v0.8.0 (#46)
+- Update actions/download-artifact action to v7 (#47)
+- Update pre-commit hook rhysd/actionlint to v1.7.11 (#45)
+- Update pre-commit hook python-jsonschema/check-jsonschema to v0.36.2 (#44)
+- Update dependency astral-sh/uv to v0.10.3 (#42)
+- Update pre-commit hook astral-sh/uv-pre-commit to v0.10.3 (#43)
+
 ## [0.3.0] - 2026-02-13
 
-### 💼 Other
+### Changed
 
-- Bump version 0.2.1 → 0.3.0
+- Add `repository` and `ref` as aliases for template configuration keys (#41)
+- Sync (#39)
+- Sync
+
+### Fixed
+
+- Fix pdoc documentation including __pycache__ directories
+- Fix broken link to non-existent book/README.md
+
+### Dependencies
+
+- Update pre-commit hook astral-sh/uv-pre-commit to v0.10.2 (#37)
+- Update pre-commit hook jebel-quant/rhiza-hooks to v0.2.1 (#38)
+- Update dependency astral-sh/uv to v0.10.1 (#36)
+
 ## [0.2.1] - 2026-02-08
 
-### 💼 Other
+### Changed
 
-- Bump version 0.2.0 → 0.2.1
+- Do not push to pypi
+
 ## [0.2.0] - 2026-02-08
 
-### 💼 Other
+### Changed
 
+- Refactor complex functions to reduce cyclomatic complexity (#35)
+- Achieve 100% test coverage for rhiza-hooks (#34)
+- Add CodeFactor badge to README (#33)
+- Hooks (#32)
+- Delete .github/workflows/hooks_release.yml (#31)
 - Adopt src layout for package structure (#30)
-- Bump version 0.1.6 → 0.2.0
+- Sync (#28)
+- Tschm patch 1 (#27)
+- Delete .rhiza/template-bundles.yml
+- Update pre commit (#26)
+
+### Fixed
+
+- Fix linting issues and apply code formatting
+
+### Maintenance
+
+- Tests (#29)
+
 ## [0.1.6] - 2026-02-05
 
-### 💼 Other
+### Fixed
 
-- Bump version 0.1.5 → 0.1.6
+- Fix check-template-bundles hook path resolution and add template filtering (#25)
+
 ## [0.1.5] - 2026-02-05
 
-### 💼 Other
+### Changed
 
-- Bump version 0.1.4 → 0.1.5
+- Delete .rhiza/make.d/02-book.mk (#23)
+- Delete book/marimo/notebooks directory (#22)
+- Delete .github/workflows/rhiza_benchmarks.yml (#20)
+- Delete .github/workflows/rhiza_book.yml (#21)
+- Add template-bundles.yml validator with dependency checking (#19)
+
 ## [0.1.4] - 2026-02-05
 
-### 🐛 Bug Fixes
+### Changed
+
+- Update README.md
+- Make "include" and "templates" optional in template.yml validation (with mutual requirement) (#15)
+- Deactivate the make help output
+- Fmt
+- Sync
+- Sync
+- Revert "fmt"
+- Fmt
+
+### Fixed
 
 - Patch subprocess directly in module execution test
 
-### 💼 Other
-
-- Bump version 0.1.3 → 0.1.4
-
-### 🧪 Testing
+### Maintenance
 
 - Increase test coverage to 100%
+
+### Dependencies
+
+- Update pre-commit hook astral-sh/uv-pre-commit to v0.9.30 (#13)
+- Update dependency astral-sh/uv to v0.9.30 (#11)
+- Update ghcr.io/astral-sh/uv docker tag to v0.9.30 (#12)
+- Update pre-commit hook abravalheri/validate-pyproject to v0.25 (#9)
+- Update github/codeql-action action to v4.32.1 (#8)
+- Update astral-sh/setup-uv action to v7 (#7)
+- Update actions/checkout action to v6 (#5)
+- Update actions/setup-python action to v6 (#6)
+- Update dependency python to 3.14 (#4)
+
 ## [0.1.3] - 2026-02-02
 
-### 💼 Other
+### Fixed
 
-- Bump version 0.1.2 → 0.1.3
+- Fix relesae
+
 ## [0.1.2] - 2026-02-01
 
-### 💼 Other
+### Changed
 
-- Bump version 0.1.1 → 0.1.2
+- Use make test
+
+### Maintenance
+
+- Update template
+
 ## [0.1.1] - 2026-02-01
 
-### 💼 Other
+### Changed
 
-- Bump version 0.1.0 → 0.1.1
+- Configure bumpversion for hooks
+- Make fmt
+- Add yaml types for mypy
+- Make fmt
+- Bring coverage > 90%
+- Make sync exclude cfg
+- Add release pipeline and README update
+
+### Fixed
+
+- Fix bugs and override source
+
 ## [0.1.0] - 2026-02-01
+
+### Changed
+
+- Initial
+
+

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,74 @@
+# git-cliff configuration (issue #123)
+#
+# Produces a human-facing "Keep a Changelog" CHANGELOG.md instead of a flat dump of
+# commit subjects under "Other"/"Miscellaneous". The release pipeline already runs
+# `git-cliff --output CHANGELOG.md` (and `--latest` for release notes); git-cliff
+# auto-detects this file, so the committed CHANGELOG and the generated release notes
+# stay consistent.
+#
+# How it stays readable:
+#   - Conventional commits are grouped into Added / Changed / Fixed / etc.
+#   - Dependency bumps are collected into a separate, de-emphasized "Dependencies"
+#     section, and template-sync chores into "Maintenance".
+#   - Pure mechanical noise (version bumps, "[skip ci]" CHANGELOG commits) is dropped.
+# Write commits as Conventional Commits (feat:/fix:/docs: …) to get the most out of it.
+
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
+"""
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | striptags | trim | upper_first }}
+{% for commit in commits %}
+- {{ commit.message | split(pat="\n") | first | upper_first | trim }}\
+{% endfor %}
+{% endfor %}\n
+"""
+trim = true
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+split_commits = false
+protect_breaking_commits = false
+filter_commits = true
+topo_order = false
+sort_commits = "newest"
+commit_parsers = [
+    # --- Drop pure mechanical noise -------------------------------------------------
+    { message = "(?i)^chore: bump version", skip = true },
+    { message = "(?i)^bump version", skip = true },
+    { message = "(?i)update changelog", skip = true },
+    { message = "\\[skip ci\\]", skip = true },
+
+    # --- De-emphasized: dependency and template maintenance -------------------------
+    { message = "(?i)^chore\\(deps", group = "<!-- 8 -->Dependencies" },
+    { message = "(?i)lock file maintenance", group = "<!-- 8 -->Dependencies" },
+    { message = "(?i)^chore: (update|bump|sync) .*(rhiza|template)", group = "<!-- 7 -->Maintenance" },
+    { message = "(?i)^(update|sync) .*(rhiza|template)", group = "<!-- 7 -->Maintenance" },
+
+    # --- User-relevant Keep a Changelog sections ------------------------------------
+    { message = "(?i)^feat", group = "<!-- 0 -->Added" },
+    { message = "(?i)^fix", group = "<!-- 4 -->Fixed" },
+    { message = "(?i)^perf", group = "<!-- 1 -->Changed" },
+    { message = "(?i)^refactor", group = "<!-- 1 -->Changed" },
+    { message = "(?i)^revert", group = "<!-- 1 -->Changed" },
+    { message = "(?i)^docs", group = "<!-- 6 -->Documentation" },
+    { message = "(?i)^test", group = "<!-- 7 -->Maintenance" },
+    { message = "(?i)^(chore|build|ci|style)", group = "<!-- 7 -->Maintenance" },
+
+    # --- Fallback: anything left is a change worth listing --------------------------
+    { message = ".*", group = "<!-- 1 -->Changed" },
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,21 @@ authors = [
     { name = "Thomas Schmelzer" }
 ]
 classifiers = [
+    # Deliberate PyPI kill-switch (issue #121): this package is intentionally NOT
+    # published to PyPI. The release pipeline (GitHub release, SBOM, CHANGELOG) still
+    # runs on tags, but rhiza_release.yml skips the PyPI publish step whenever this
+    # classifier is present. Remove it ONLY if you intend to publish to PyPI, and only
+    # after registering the project as a PyPI Trusted Publisher.
     "Private :: Do Not Upload",
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    # The Python version trove classifiers below are the single source of truth for
+    # the CI test matrix (issue #119): `make version-matrix` (rhiza-tools) reads them
+    # from this file, and the upstream rhiza_ci.yml reusable workflow tests every
+    # listed version across ubuntu/macos/windows. Keep them in sync with what is
+    # actually supported — adding/removing one changes CI coverage automatically.
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,8 +1,12 @@
 [pytest]
 testpaths = tests
-# Enable live logs on console
-log_cli = true
-# Show DEBUG+ messages
+# Live console logging is OFF by default (issue #120) so normal `pytest` / `make test`
+# runs aren't buried under DEBUG output (which also hid the summary and the coverage
+# report when piping). The format/level settings below are retained so opting in needs
+# only a single flag. To opt in when debugging, re-enable it on the command line:
+#   pytest -o log_cli=true --log-cli-level=DEBUG
+log_cli = false
+# Level used when live logging is opted into (see above)
 log_cli_level = DEBUG
 log_cli_format = %(asctime)s %(levelname)s %(name)s: %(message)s
 log_cli_date_format = %H:%M:%S


### PR DESCRIPTION
Addresses all five open issues. Each is config/metadata/docs — no `src/` changes.

## #119 — Confirm CI tests the full Python matrix (3.11–3.14)
**Verified.** The CI matrix is generated dynamically by `make version-matrix` (rhiza-tools), which reads the `Programming Language :: Python :: 3.x` trove classifiers from `pyproject.toml`. Confirmed locally it emits `["3.11","3.12","3.13","3.14"]`, and the upstream `rhiza_ci.yml@v0.18.8` runs that matrix across `ubuntu/macos/windows`. The classifiers are **not** aspirational — they directly drive CI. Documented this source-of-truth relationship in a comment next to the classifiers.

## #120 — Test output is noisy by default (`log_cli=true` at DEBUG)
Set `log_cli = false` in `pytest.ini`. The level/format settings are retained so opting back in needs a single flag, documented inline: `pytest -o log_cli=true --log-cli-level=DEBUG`. Confirmed clean output (no DEBUG flood) with 230 tests passing.

## #121 — Contradictory packaging intent
**Decision: keep it private.** `Private :: Do Not Upload` is the deliberate kill-switch that `rhiza_release.yml` honors to skip the PyPI publish step (the rest of the pipeline — GitHub release, SBOM, CHANGELOG — still runs intentionally). Documented this in a comment so it no longer reads as a contradiction.

## #122 — Promote development status Alpha → Beta
Bumped `Development Status :: 3 - Alpha` → `4 - Beta`. Rationale (large test suite + enforced 100% branch-coverage gate at v0.5.1) is in the commit message, which surfaces in the auto-generated CHANGELOG.

## #123 — Make CHANGELOG human-readable
Added `cliff.toml` (auto-detected by the `git-cliff` step in `rhiza_release.yml`) producing Keep a Changelog sections (Added/Changed/Fixed/Documentation), with dependency bumps collected into a de-emphasized **Dependencies** section, template-sync into **Maintenance**, and version-bump/`[skip ci]` noise dropped. Regenerated `CHANGELOG.md` so the committed file matches future release output.

Closes #119
Closes #120
Closes #121
Closes #122
Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)