### PR TITLE
docs: update README pre-commit rev example to v0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add to your `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v0.1.0  # Use the latest release
+    rev: v0.5.1  # Use the latest release
     hooks:
       # Migrated from rhiza
       - id: check-rhiza-workflow-names


### PR DESCRIPTION
The quick-start example pinned rev: v0.1.0 while the package is at v0.5.1. Update it to match the current release.
