### PR TITLE
test: add Hypothesis property-based tests (makes docs report link live)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ test = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "pytest-timeout>=2.3",
+    "hypothesis>=6.0",
 ]
 lint = [
     "ruff>=0.15.16,<1.0",

--- a/tests/test_property_based.py
+++ b/tests/test_property_based.py
@@ -1,0 +1,114 @@
+"""Property-based tests (Hypothesis) for the pure parsing/validation helpers.
+
+These exercise algebraic invariants rather than fixed examples, and are collected
+by the ``make hypothesis-test`` target (``-m "hypothesis or property"``); the
+``@given`` decorator applies Hypothesis' own ``hypothesis`` marker automatically.
+"""
+
+from __future__ import annotations
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from rhiza_hooks.check_python_version import parse_version, version_satisfies_constraint
+from rhiza_hooks.check_rhiza_config import KEY_ALIASES, _normalize_config
+
+# Version components kept small but representative; the helpers only ever compare
+# (major, minor) tuples, so the exact magnitude is irrelevant to the invariants.
+_components = st.integers(min_value=0, max_value=99)
+
+
+def _version_str(major: int, minor: int) -> str:
+    return f"{major}.{minor}"
+
+
+class TestParseVersion:
+    """Invariants for parse_version."""
+
+    @given(_components, _components)
+    def test_roundtrip(self, major: int, minor: int) -> None:
+        """Formatting a (major, minor) pair and parsing it returns the pair."""
+        assert parse_version(_version_str(major, minor)) == (major, minor)
+
+
+class TestVersionSatisfiesConstraint:
+    """Algebraic invariants for version_satisfies_constraint.
+
+    The function compares (major, minor) tuples under a total order, so each
+    operator has a dual / negation that must hold for *every* pair of versions.
+    """
+
+    @given(_components, _components, _components, _components)
+    def test_ge_is_mirror_of_le(self, a_maj: int, a_min: int, b_maj: int, b_min: int) -> None:
+        """Mirror identity: a >= b holds exactly when b <= a."""
+        a, b = _version_str(a_maj, a_min), _version_str(b_maj, b_min)
+        assert version_satisfies_constraint(a, ">=", b) == version_satisfies_constraint(b, "<=", a)
+
+    @given(_components, _components, _components, _components)
+    def test_gt_is_mirror_of_lt(self, a_maj: int, a_min: int, b_maj: int, b_min: int) -> None:
+        """Mirror identity: a > b holds exactly when b < a."""
+        a, b = _version_str(a_maj, a_min), _version_str(b_maj, b_min)
+        assert version_satisfies_constraint(a, ">", b) == version_satisfies_constraint(b, "<", a)
+
+    @given(_components, _components, _components, _components)
+    def test_ge_negates_lt(self, a_maj: int, a_min: int, b_maj: int, b_min: int) -> None:
+        """Total order: a >= b is exactly the negation of a < b."""
+        a, b = _version_str(a_maj, a_min), _version_str(b_maj, b_min)
+        assert version_satisfies_constraint(a, ">=", b) != version_satisfies_constraint(a, "<", b)
+
+    @given(_components, _components, _components, _components)
+    def test_eq_negates_ne(self, a_maj: int, a_min: int, b_maj: int, b_min: int) -> None:
+        """Equality is exactly the negation of inequality (== versus !=)."""
+        a, b = _version_str(a_maj, a_min), _version_str(b_maj, b_min)
+        assert version_satisfies_constraint(a, "==", b) != version_satisfies_constraint(a, "!=", b)
+
+    @given(_components, _components)
+    def test_empty_operator_means_equality(self, major: int, minor: int) -> None:
+        """An empty operator behaves like '==' (documented default)."""
+        v = _version_str(major, minor)
+        assert version_satisfies_constraint(v, "", v) is True
+
+    @given(_components, _components, _components, _components)
+    def test_compatible_release_implies_lower_bound(self, a_maj: int, a_min: int, b_maj: int, b_min: int) -> None:
+        """Compatible-release ~= refines >=: it never accepts what >= rejects."""
+        a, b = _version_str(a_maj, a_min), _version_str(b_maj, b_min)
+        if version_satisfies_constraint(a, "~=", b):
+            assert version_satisfies_constraint(a, ">=", b)
+            assert a_maj == b_maj
+
+    @given(_components, _components, _components, _components)
+    def test_unknown_operator_is_permissive(self, a_maj: int, a_min: int, b_maj: int, b_min: int) -> None:
+        """Unrecognised operators are accepted permissively (documented behaviour)."""
+        a, b = _version_str(a_maj, a_min), _version_str(b_maj, b_min)
+        assert version_satisfies_constraint(a, "?!", b) is True
+
+
+class TestNormalizeConfig:
+    """Invariants for _normalize_config."""
+
+    # Keys drawn from aliases, their canonical targets, and arbitrary unrelated keys.
+    _keys = st.sampled_from(sorted(set(KEY_ALIASES) | set(KEY_ALIASES.values()) | {"unrelated", "other"}))
+    _configs = st.dictionaries(_keys, st.integers(), max_size=6)
+
+    @given(_configs)
+    def test_no_alias_survives_normalization(self, config: dict[str, int]) -> None:
+        """After normalization, no raw alias key remains in the output."""
+        normalized = _normalize_config(config)
+        assert not (set(normalized) & set(KEY_ALIASES))
+
+    @given(_configs)
+    def test_idempotent(self, config: dict[str, int]) -> None:
+        """Canonical keys map to themselves, so normalizing twice == once."""
+        once = _normalize_config(config)
+        assert _normalize_config(once) == once
+
+    @given(_configs)
+    def test_value_count_preserved_without_alias_collisions(self, config: dict[str, int]) -> None:
+        """When no key and its alias coexist, normalization is key-count preserving."""
+        # Build an input guaranteed free of alias/canonical collisions.
+        canonical_to_aliases: dict[str, str] = {v: k for k, v in KEY_ALIASES.items()}
+        safe = {
+            k: v for k, v in config.items() if not (k in canonical_to_aliases and canonical_to_aliases[k] in config)
+        }
+        normalized = _normalize_config(safe)
+        assert len(normalized) == len(safe)

--- a/uv.lock
+++ b/uv.lock
@@ -168,6 +168,18 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.155.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/04/64032a1dccd2233615c8a3f701bbb563558575ed017496a24b6d81762c91/hypothesis-6.155.2.tar.gz", hash = "sha256:ae36880287c9c5defe9f199d3d2b67d9947a4da2a46e6c57373cbdf2345b20e1", size = 477765, upload-time = "2026-06-05T16:32:23.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/6e/e735f27ac1a530a4cd0a31cd970ec495a3a11830fdc5d281cc292593b330/hypothesis-6.155.2-py3-none-any.whl", hash = "sha256:c85ce6dcd630a90ce501f1d1dd1bc84b97f5649ca8a27e134c8cbf5aa480b1a5", size = 544213, upload-time = "2026-06-05T16:32:21.15Z" },
+]
+
+[[package]]
 name = "identify"
 version = "2.6.19"
 source = { registry = "https://pypi.org/simple" }
@@ -542,6 +554,7 @@ lint = [
     { name = "types-pyyaml" },
 ]
 test = [
+    { name = "hypothesis" },
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-timeout" },
@@ -560,6 +573,7 @@ lint = [
     { name = "types-pyyaml", specifier = ">=6.0.12.20260518" },
 ]
 test = [
+    { name = "hypothesis", specifier = ">=6.0" },
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=5.0" },
     { name = "pytest-timeout", specifier = ">=2.3" },
@@ -588,6 +602,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
     { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
     { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The MkDocs nav links a Hypothesis report (`reports/hypothesis/report.html`) and the rhiza `hypothesis-test` make target already exists — but no property-based tests had been written, so the report never generated and the nav link was dead (#126).

This adds algebraic-invariant property tests for the pure helpers, which makes `make hypothesis-test` produce the report (verified locally):

- **`parse_version`** — round-trip of `(major, minor)`.
- **`version_satisfies_constraint`** — operator duals/negations that must hold for *every* version pair: `>=` mirrors `<=`, `>` mirrors `<`, `>=` negates `<`, `==` negates `!=`, `~=` refines `>=`, and the empty/unknown-operator behaviours.
- **`_normalize_config`** — no alias survives normalization, idempotence, and key-count preservation absent alias collisions.

`hypothesis>=6.0` added to the `test` dependency group. Full suite stays at **100% coverage (241 passed)**; ruff/deptry clean.

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)