### PR TITLE
docs: surface CODE_OF_CONDUCT & CONTRIBUTING at .github/ path

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of Conduct
+
+The canonical Code of Conduct for this project is maintained as part of the
+shared [Rhiza](https://github.com/Jebel-Quant/rhiza) template and lives at
+[`.rhiza/CODE_OF_CONDUCT.md`](../.rhiza/CODE_OF_CONDUCT.md).
+
+This file exists at a GitHub-recognized path (`.github/`) so the Code of Conduct
+is surfaced in the repository's community profile. To change the policy, edit the
+linked canonical file (it is managed by the template sync) rather than this pointer.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing
+
+The canonical contribution guide for this project is maintained as part of the
+shared [Rhiza](https://github.com/Jebel-Quant/rhiza) template and lives at
+[`.rhiza/CONTRIBUTING.md`](../.rhiza/CONTRIBUTING.md).
+
+This file exists at a GitHub-recognized path (`.github/`) so the contribution
+guide is surfaced in the repository's community profile and linked from the new
+issue / pull request screens. To change the guidance, edit the linked canonical
+file (it is managed by the template sync) rather than this pointer.


### PR DESCRIPTION
The canonical community files are template-managed under `.rhiza/`, a path GitHub does not recognize — so they were missing from the repository's community profile and the new-issue / new-PR screens (#130).

This adds thin **pointer files** at `.github/` (a GitHub-recognized path) linking to the canonical `.rhiza/` versions:
- `.github/CODE_OF_CONDUCT.md` → `.rhiza/CODE_OF_CONDUCT.md`
- `.github/CONTRIBUTING.md` → `.rhiza/CONTRIBUTING.md`

**Why pointers, not copies:** the `.rhiza/` files are overwritten by the rhiza template sync (the `legal` template), so full copies would silently drift. Pointers keep a single source of truth while still letting GitHub surface both documents.

Closes #130

🤖 Generated with [Claude Code](https://claude.com/claude-code)