### PR TITLE
docs: surface changelog in MkDocs nav

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,2 @@
+<!-- Keep the published release notes in sync with the single root CHANGELOG. -->
+--8<-- "../CHANGELOG.md"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ docs_dir: docs
 
 nav:
   - Home: index.md
+  - Changelog: changelog.md
   - API Reference:
       - Overview: api-reference/index.md
       - check_makefile_targets: api-reference/check_makefile_targets.md


### PR DESCRIPTION
## Summary
- add a Changelog entry to the MkDocs navigation
- publish the root `CHANGELOG.md` through a thin docs wrapper so release notes stay single-sourced

Closes #127

## Validation
- `noglob uvx --with mkdocs-material --with 'mkdocstrings[python]' --with mkdocs-include-markdown-plugin --with-editable . mkdocs build`\n\n## Notes\n- the MkDocs build still reports the existing report HTML references and `LICENSE` relative-link info from the current repo state; this change does not alter those warnings.