### PR TITLE
fix(ci): correct unresolvable scorecard-action SHA pin

### DIFF
--- a/.github/workflows/rhiza_scorecard.yml
+++ b/.github/workflows/rhiza_scorecard.yml
@@ -37,7 +37,7 @@ jobs:
           persist-credentials: false
 
       - name: Run Scorecard analysis
-        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75b087d4c3 # v2.4.1
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
The **(RHIZA) SCORECARD** workflow fails on every run at the action-resolution step:

```
Error: Unable to resolve action `ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75b087d4c3`,
unable to find version `f49aabe0b5af0936a0987cfb85d86b75b087d4c3`
```

The pinned SHA is corrupted — it claims to be `v2.4.1` but that commit doesn't exist (the real v2.4.1 is `f49aabe0b5af0936a0987cfb85d86b75731b0186`; the bad pin diverges after the first 21 chars).

**Fix:** repin to **v2.4.3** at its verified commit SHA `4eaacf0543bb3f2c246792bd56e8cdeffafb205a` (dereferenced from the annotated tag and confirmed to exist via the GitHub API).

actionlint + workflow-schema checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)