### PR TITLE
Address remaining hook issues: makefile targets, fetch retry/offline, config & docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -92,7 +92,7 @@ repos:
         files: ^src/
 
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v0.4.0  # Use the latest release
+    rev: v0.6.2  # Use the latest release
     hooks:
       # Migrated from rhiza
       - id: check-rhiza-workflow-names
@@ -101,4 +101,10 @@ repos:
       - id: check-rhiza-config
       - id: check-makefile-targets
       - id: check-python-version-consistency
+      # check-template-bundles is intentionally NOT enabled here: it fetches
+      # template-bundles.yml over the network from the template repo on every
+      # run, which would make local commits depend on network access. It runs
+      # in CI instead. To validate locally on demand, run it directly:
+      #   pre-commit run --hook-stage manual check-template-bundles --all-files
+      # or skip the network with `check-template-bundles --offline`.
       # - id: check-template-bundles

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Add to your `.pre-commit-config.yaml`:
 ```yaml
 repos:
   - repo: https://github.com/Jebel-Quant/rhiza-hooks
-    rev: v0.5.1  # Use the latest release
+    rev: v0.6.2  # Use the latest release
     hooks:
       # Migrated from rhiza
       - id: check-rhiza-workflow-names
@@ -39,6 +39,17 @@ pre-commit install
 ```
 
 ## 📋 Available Hooks
+
+| Hook | Triggers on | Autofixes? | Exit code |
+| --- | --- | --- | --- |
+| `check-rhiza-workflow-names` | `.github/workflows/rhiza_*.yml` | ✅ rewrites a wrong `name:` | `1` if any file was changed or has an error, else `0` |
+| `update-readme-help` | `Makefile` | ✅ rewrites `README.md` between markers | `1` if `README.md` was changed, else `0` (never fails when `make help` is unavailable) |
+| `check-rhiza-config` | `.rhiza/template.yml` | ❌ validates only | `1` if invalid, else `0` |
+| `check-makefile-targets` | `Makefile`, `.rhiza/*.mk` | ❌ warns only | `0` by default (warn-only); `1` on missing targets **only** with `--strict` |
+| `check-python-version-consistency` | `.python-version`, `pyproject.toml` | ❌ validates only | `1` on mismatch, else `0` |
+| `check-template-bundles` | `.rhiza/template.yml` | ❌ validates only (network) | `1` on validation failure, else `0`; `0` when `--offline` |
+
+Details for each hook follow.
 
 ### Migrated from Rhiza
 
@@ -96,11 +107,24 @@ Checks that your Makefile contains recommended targets for rhiza-based projects:
 
 By default, this hook only warns about missing targets. Use `--strict` to fail on missing targets.
 
+The expected set can be customised:
+
+- `--target NAME` (repeatable) **replaces** the default set with exactly the targets you list.
+- `--extend-target NAME` (repeatable) **adds** to the active set (defaults, or whatever `--target` selected).
+
 **Usage:**
 
 ```yaml
 - id: check-makefile-targets
   args: [--strict]  # Optional: fail if targets are missing
+
+# Require a custom set instead of the defaults:
+- id: check-makefile-targets
+  args: [--target, build, --target, lint]
+
+# Keep the defaults and also require `deploy`:
+- id: check-makefile-targets
+  args: [--extend-target, deploy]
 ```
 
 #### `check-python-version-consistency`
@@ -124,10 +148,13 @@ Validates templates specified in `.rhiza/template.yml` against the `template-bun
 
 **Triggers on:** Changes to `.rhiza/template.yml`
 
+This hook reaches the network on every run. A transient failure is retried once with a short backoff before giving up; pass `--offline` to skip the remote fetch entirely (the hook then passes without validating), which is useful for offline commits.
+
 **Usage:**
 
 ```yaml
 - id: check-template-bundles
+  # args: [--offline]  # Optional: skip the network fetch and pass
 ```
 
 ## 🛠️ Development
@@ -172,6 +199,29 @@ pre-commit try-repo . --all-files
 # Test a specific hook
 pre-commit try-repo . check-rhiza-config --files .rhiza/template.yml
 ```
+
+### Tests, coverage & mutation testing
+
+This project enforces **100% line/branch coverage** and a **100% mutation score** (via [`mutmut`](https://github.com/boxed/mutmut)). Both gates run in CI, but you can reproduce them locally before opening a PR:
+
+```bash
+make test       # Run the suite with coverage (fails under 100%)
+make mutation   # Run mutation testing (fails on any surviving mutant)
+```
+
+`make mutation` writes an HTML report to `_tests/mutation/html/index.html` — open it to see exactly which mutants survived and which test should have caught each one. `mutmut results` lists survivors on the command line.
+
+Coverage proves a line ran; mutation testing proves a wrong result would be *caught*. When a mutant survives, the fix is almost always a stronger assertion (pin the exact value/message rather than asserting "truthy").
+
+#### Equivalent mutants
+
+Occasionally a mutant is genuinely **equivalent** — it changes the code without changing any observable behaviour, so no test can kill it (e.g. swapping a boolean initializer that is only ever read in a truthiness check between `False` and `None`). Mark only these with a `# pragma: no mutate` comment that states *why* it is equivalent, e.g.:
+
+```python +RHIZA_SKIP
+failed = False  # pragma: no mutate  # equivalent: only ever read via `if failed`
+```
+
+Reach for the pragma sparingly and only after confirming no assertion can distinguish the mutant — a real, killable mutant should be killed with a test, not suppressed.
 
 ## 📄 License
 

--- a/src/rhiza_hooks/check_makefile_targets.py
+++ b/src/rhiza_hooks/check_makefile_targets.py
@@ -41,11 +41,12 @@ def extract_targets(content: str) -> set[str]:
     return set(matches)
 
 
-def check_makefile(filepath: Path) -> list[str]:
+def check_makefile(filepath: Path, recommended: set[str] = RECOMMENDED_TARGETS) -> list[str]:
     """Check a Makefile for recommended targets.
 
     Args:
         filepath: Path to the Makefile
+        recommended: Target names that must be present (defaults to RECOMMENDED_TARGETS)
 
     Returns:
         List of warning messages (empty if all recommended targets exist)
@@ -61,11 +62,25 @@ def check_makefile(filepath: Path) -> list[str]:
 
     # Only check the main Makefile for recommended targets
     if filepath.name == "Makefile":
-        missing = RECOMMENDED_TARGETS - targets
+        missing = recommended - targets
         if missing:
             warnings.append(f"Missing recommended targets: {', '.join(sorted(missing))}")
 
     return warnings
+
+
+def resolve_recommended_targets(targets: list[str] | None, extra_targets: list[str] | None) -> set[str]:
+    """Build the effective set of required targets from the CLI options.
+
+    Args:
+        targets: Values of ``--target``. When non-empty they *replace* the defaults.
+        extra_targets: Values of ``--extend-target``, always *added* to the active set.
+
+    Returns:
+        The set of target names a Makefile is expected to define.
+    """
+    base = set(targets) if targets else set(RECOMMENDED_TARGETS)
+    return base | set(extra_targets or [])
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -81,12 +96,26 @@ def main(argv: list[str] | None = None) -> int:
         action="store_true",
         help="Exit with error if recommended targets are missing",
     )
+    parser.add_argument(
+        "--target",
+        action="append",
+        metavar="NAME",
+        help="Required target name; repeatable. When given, replaces the default set.",
+    )
+    parser.add_argument(
+        "--extend-target",
+        action="append",
+        metavar="NAME",
+        help="Extra required target name; repeatable. Added on top of the active set.",
+    )
     args = parser.parse_args(argv)
+
+    recommended = resolve_recommended_targets(args.target, args.extend_target)
 
     retval = 0
     for filename in args.filenames:
         filepath = Path(filename)
-        warnings = check_makefile(filepath)
+        warnings = check_makefile(filepath, recommended)
         if warnings:
             print(f"{filename}:")
             for warning in warnings:

--- a/src/rhiza_hooks/check_template_bundles.py
+++ b/src/rhiza_hooks/check_template_bundles.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import io
 import sys
+import time
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, cast
@@ -31,6 +32,11 @@ from urllib.request import urlopen
 import yaml
 
 from rhiza_hooks._repo import find_repo_root
+
+# Remote fetch is retried on transient network errors before giving up. Two
+# attempts = one initial try plus one retry, with a short linear backoff.
+_FETCH_ATTEMPTS = 2
+_FETCH_BACKOFF_SECONDS = 1.0
 
 
 def _load_yaml_file(bundles_path: Path) -> tuple[bool, dict[Any, Any] | list[str]]:
@@ -188,36 +194,12 @@ def _get_templates_from_config(config_path: Path) -> set[str] | None:
     return cast(set[str], set(templates))
 
 
-def _fetch_remote_bundles(repo: str, branch: str) -> tuple[bool, dict[Any, Any] | list[str]]:
-    """Fetch template-bundles.yml from a remote GitHub repository.
-
-    Args:
-        repo: GitHub repository in 'owner/repo' format
-        branch: Branch name
+def _parse_remote_bundles(content: bytes) -> tuple[bool, dict[Any, Any] | list[str]]:
+    """Parse fetched template-bundles.yml content.
 
     Returns:
         Tuple of (success, data_or_errors)
     """
-    # Construct GitHub raw content URL
-    url = f"https://raw.githubusercontent.com/{repo}/{branch}/.rhiza/template-bundles.yml"
-
-    # Validate URL scheme for security (bandit B310)
-    parsed = urlparse(url)
-    if parsed.scheme != "https":
-        return False, [f"Invalid URL scheme: {parsed.scheme}. Only https is allowed."]
-
-    try:
-        with urlopen(url, timeout=10) as response:  # noqa: S310  # nosec B310
-            content = response.read()
-    except HTTPError as e:
-        if e.code == 404:
-            return False, [f"Template bundles file not found in repository {repo} (branch: {branch})"]
-        return False, [f"HTTP error fetching template bundles: {e.code} {e.reason}"]
-    except URLError as e:
-        return False, [f"Error fetching template bundles from {url}: {e.reason}"]
-    except TimeoutError:
-        return False, [f"Timeout fetching template bundles from {url}"]
-
     try:
         data = yaml.safe_load(content)
     except yaml.YAMLError as e:
@@ -230,6 +212,60 @@ def _fetch_remote_bundles(repo: str, branch: str) -> tuple[bool, dict[Any, Any] 
         return False, ["Remote template bundles must be a dictionary"]
 
     return True, data
+
+
+def _fetch_remote_bundles(
+    repo: str,
+    branch: str,
+    attempts: int = _FETCH_ATTEMPTS,
+    backoff: float = _FETCH_BACKOFF_SECONDS,
+) -> tuple[bool, dict[Any, Any] | list[str]]:
+    """Fetch template-bundles.yml from a remote GitHub repository.
+
+    Transient network failures (`URLError`/`TimeoutError`) are retried up to
+    ``attempts`` times with a linear backoff. HTTP errors (e.g. 404) are
+    permanent and returned immediately without retrying.
+
+    Args:
+        repo: GitHub repository in 'owner/repo' format
+        branch: Branch name
+        attempts: Total number of fetch attempts (initial try + retries)
+        backoff: Base seconds to sleep between attempts (multiplied by attempt number)
+
+    Returns:
+        Tuple of (success, data_or_errors)
+    """
+    # Construct GitHub raw content URL
+    url = f"https://raw.githubusercontent.com/{repo}/{branch}/.rhiza/template-bundles.yml"
+
+    # Validate URL scheme for security (bandit B310)
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        return False, [f"Invalid URL scheme: {parsed.scheme}. Only https is allowed."]
+
+    # pragma below: equivalent mutant — the final `return False, errors` is only reached
+    # after a transient-error iteration has reassigned `errors` (success and HTTP errors
+    # return early), so for attempts >= 1 this initial value is never the one returned.
+    errors: list[str] = []  # pragma: no mutate
+    for attempt in range(attempts):
+        try:
+            with urlopen(url, timeout=10) as response:  # noqa: S310  # nosec B310
+                content = response.read()
+        except HTTPError as e:
+            if e.code == 404:
+                return False, [f"Template bundles file not found in repository {repo} (branch: {branch})"]
+            return False, [f"HTTP error fetching template bundles: {e.code} {e.reason}"]
+        except URLError as e:
+            errors = [f"Error fetching template bundles from {url}: {e.reason}"]
+        except TimeoutError:
+            errors = [f"Timeout fetching template bundles from {url}"]
+        else:
+            return _parse_remote_bundles(content)
+        # Transient failure: back off before the next attempt (linear: backoff, 2*backoff, ...).
+        if attempt + 1 < attempts:
+            time.sleep(backoff * (attempt + 1))
+
+    return False, errors
 
 
 def _validate_selected_bundles(
@@ -399,7 +435,16 @@ def main(argv: list[str] | None = None) -> int:
         nargs="*",
         help="Filenames to check (should be .rhiza/template.yml)",
     )
+    parser.add_argument(
+        "--offline",
+        action="store_true",
+        help="Skip the remote bundles fetch (e.g. for offline commits) and pass",
+    )
     args = parser.parse_args(argv)
+
+    if args.offline:
+        print("Offline mode: skipping remote template bundles validation")
+        return 0
 
     # Get configuration path
     config_path = _get_config_path(args)

--- a/src/rhiza_hooks/check_workflow_names.py
+++ b/src/rhiza_hooks/check_workflow_names.py
@@ -67,7 +67,10 @@ def check_file(filepath: str) -> bool:
                     if line.strip() == "" or line.startswith(" "):
                         continue
                     skipping_block = False  # pragma: no mutate  # equivalent: only ever read via `if skipping_block`
-                # Replace only the top-level name field (assumes it starts at beginning of line)
+                # Replace only the top-level workflow `name`. It is the sole `name:` key
+                # at column 0; job- and step-level `name:` keys are nested and therefore
+                # indented, so `startswith("name:")` never matches them. `not replaced`
+                # also stops us after the first match (a duplicate top-level key).
                 if not replaced and line.startswith("name:"):
                     f_write.write(f'name: "{expected_name}"\n')
                     replaced = True

--- a/tests/test_check_makefile_targets.py
+++ b/tests/test_check_makefile_targets.py
@@ -10,6 +10,7 @@ from rhiza_hooks.check_makefile_targets import (
     check_makefile,
     extract_targets,
     main,
+    resolve_recommended_targets,
 )
 
 
@@ -145,6 +146,35 @@ install:
         # Should not warn about missing targets for non-Makefile files
         assert warnings == []
 
+    def test_custom_recommended_set(self, tmp_path: Path) -> None:
+        """A custom `recommended` set replaces the default expectations."""
+        makefile = tmp_path / "Makefile"
+        makefile.write_text("build:\n\techo hi\n")
+        # `build` satisfies a custom set; the default install/test/fmt/help are not required.
+        assert check_makefile(makefile, {"build"}) == []
+        # A custom target that is absent is reported.
+        assert check_makefile(makefile, {"deploy"}) == ["Missing recommended targets: deploy"]
+
+
+class TestResolveRecommendedTargets:
+    """Tests for resolve_recommended_targets."""
+
+    def test_defaults_when_no_options(self) -> None:
+        """With no options the default recommended set is used."""
+        assert resolve_recommended_targets(None, None) == {"install", "test", "fmt", "help"}
+
+    def test_target_replaces_defaults(self) -> None:
+        """`--target` values replace the defaults entirely."""
+        assert resolve_recommended_targets(["build", "lint"], None) == {"build", "lint"}
+
+    def test_extend_target_adds_to_defaults(self) -> None:
+        """`--extend-target` adds to the active set, keeping the defaults."""
+        assert resolve_recommended_targets(None, ["deploy"]) == {"install", "test", "fmt", "help", "deploy"}
+
+    def test_target_and_extend_combine(self) -> None:
+        """`--target` replaces, then `--extend-target` adds on top."""
+        assert resolve_recommended_targets(["build"], ["deploy"]) == {"build", "deploy"}
+
 
 class TestMain:
     """Tests for main function."""
@@ -187,8 +217,30 @@ help:
         result = main([])
         assert result == 0
 
-    def test_help_text(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_main_target_override_satisfied(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        """`--target` replaces the defaults; a Makefile meeting the custom set passes quietly."""
+        makefile = tmp_path / "Makefile"
+        makefile.write_text("build:\n\techo hi\n")
+
+        result = main(["--target", "build", str(makefile)])
+
+        assert result == 0
+        assert capsys.readouterr().out == ""
+
+    def test_main_extend_target_strict_fails(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        """`--extend-target` adds a requirement; a missing extra target fails under --strict."""
+        makefile = tmp_path / "Makefile"
+        makefile.write_text("install:\ntest:\nfmt:\nhelp:\n")
+
+        result = main(["--strict", "--extend-target", "deploy", str(makefile)])
+
+        assert result == 1
+        assert capsys.readouterr().out == f"{makefile}:\n  - Missing recommended targets: deploy\n"
+
+    def test_help_text(self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch) -> None:
         """--help renders the exact argparse description and option help strings."""
+        # Pin a wide terminal so argparse doesn't wrap the longer option help mid-string.
+        monkeypatch.setenv("COLUMNS", "200")
         with pytest.raises(SystemExit) as exc_info:
             main(["--help"])
         assert exc_info.value.code == 0
@@ -199,6 +251,8 @@ help:
         assert "Check Makefile for recommended targets" in out
         assert "Filenames to check" in out
         assert "Exit with error if recommended targets are missing" in out
+        assert "Required target name; repeatable. When given, replaces the default set." in out
+        assert "Extra required target name; repeatable. Added on top of the active set." in out
 
 
 class TestModuleExecution:

--- a/tests/test_check_template_bundles.py
+++ b/tests/test_check_template_bundles.py
@@ -829,35 +829,101 @@ class TestFetchRemoteBundles:
         assert errors == ["HTTP error fetching template bundles: 500 Internal Server Error"]
 
     def test_fetch_remote_bundles_url_error(self, monkeypatch):
-        """Test fetching remote bundles with URL error."""
+        """A persistent URL error gives up after the default attempts, retrying once."""
+        from unittest.mock import MagicMock
         from urllib.error import URLError
 
         from rhiza_hooks.check_template_bundles import _fetch_remote_bundles
 
-        def mock_urlopen(url, timeout):
-            msg = "Connection refused"
-            raise URLError(msg)
+        calls = MagicMock(side_effect=URLError("Connection refused"))
 
+        def mock_urlopen(url, timeout):
+            return calls(url, timeout)
+
+        sleep = MagicMock()
         monkeypatch.setattr("rhiza_hooks.check_template_bundles.urlopen", mock_urlopen)
+        monkeypatch.setattr("rhiza_hooks.check_template_bundles.time.sleep", sleep)
 
         success, errors = _fetch_remote_bundles("test/repo", "main")
         assert success is False
         url = "https://raw.githubusercontent.com/test/repo/main/.rhiza/template-bundles.yml"
         assert errors == [f"Error fetching template bundles from {url}: Connection refused"]
+        # Default = 2 attempts (1 retry): urlopen twice, one backoff sleep of 1.0s.
+        assert calls.call_count == 2
+        assert sleep.call_args_list == [((1.0,), {})]
 
     def test_fetch_remote_bundles_timeout(self, monkeypatch):
-        """Test fetching remote bundles with timeout reports the exact message."""
+        """A persistent timeout gives up after the default attempts with the exact message."""
+        from unittest.mock import MagicMock
+
         from rhiza_hooks.check_template_bundles import _fetch_remote_bundles
 
-        def mock_urlopen(url, timeout):
-            raise TimeoutError("Timeout")
+        calls = MagicMock(side_effect=TimeoutError("Timeout"))
 
+        def mock_urlopen(url, timeout):
+            return calls(url, timeout)
+
+        sleep = MagicMock()
         monkeypatch.setattr("rhiza_hooks.check_template_bundles.urlopen", mock_urlopen)
+        monkeypatch.setattr("rhiza_hooks.check_template_bundles.time.sleep", sleep)
 
         success, errors = _fetch_remote_bundles("test/repo", "main")
         assert success is False
         url = "https://raw.githubusercontent.com/test/repo/main/.rhiza/template-bundles.yml"
         assert errors == [f"Timeout fetching template bundles from {url}"]
+        assert calls.call_count == 2
+        assert sleep.call_args_list == [((1.0,), {})]
+
+    def test_fetch_remote_bundles_retry_then_success(self, monkeypatch):
+        """A transient failure followed by success returns the parsed data after one retry."""
+        from unittest.mock import MagicMock
+        from urllib.error import URLError
+
+        from rhiza_hooks.check_template_bundles import _fetch_remote_bundles
+
+        def make_response():
+            resp = MagicMock()
+            resp.read.return_value = b"version: 1.0\nbundles: {}"
+            resp.__enter__ = lambda self: self
+            resp.__exit__ = lambda self, *args: None
+            return resp
+
+        calls = MagicMock(side_effect=[URLError("flaky"), make_response()])
+
+        def mock_urlopen(url, timeout):
+            return calls(url, timeout)
+
+        sleep = MagicMock()
+        monkeypatch.setattr("rhiza_hooks.check_template_bundles.urlopen", mock_urlopen)
+        monkeypatch.setattr("rhiza_hooks.check_template_bundles.time.sleep", sleep)
+
+        success, data = _fetch_remote_bundles("test/repo", "main")
+        assert success is True
+        assert data == {"version": 1.0, "bundles": {}}
+        assert calls.call_count == 2
+        assert sleep.call_args_list == [((1.0,), {})]
+
+    def test_fetch_remote_bundles_backoff_schedule(self, monkeypatch):
+        """Backoff is linear (backoff, 2*backoff, ...) and the last attempt does not sleep."""
+        from unittest.mock import MagicMock
+        from urllib.error import URLError
+
+        from rhiza_hooks.check_template_bundles import _fetch_remote_bundles
+
+        calls = MagicMock(side_effect=URLError("down"))
+
+        def mock_urlopen(url, timeout):
+            return calls(url, timeout)
+
+        sleep = MagicMock()
+        monkeypatch.setattr("rhiza_hooks.check_template_bundles.urlopen", mock_urlopen)
+        monkeypatch.setattr("rhiza_hooks.check_template_bundles.time.sleep", sleep)
+
+        success, _errors = _fetch_remote_bundles("test/repo", "main", attempts=3, backoff=2.0)
+        assert success is False
+        # 3 attempts -> 2 sleeps between them: 2.0 then 4.0. No sleep after the final attempt.
+        assert calls.call_count == 3
+        assert sleep.call_args_list == [((2.0,), {}), ((4.0,), {})]
 
     def test_fetch_remote_bundles_invalid_yaml(self, monkeypatch):
         """Test fetching remote bundles with invalid YAML."""
@@ -1363,3 +1429,15 @@ class TestMainExtraCoverage:
         assert "XX" not in out  # no mutated literal survived into the rendered help
         assert "Validate template-bundles.yml from remote template repository" in out
         assert "Filenames to check (should be .rhiza/template.yml)" in out
+
+    def test_offline_skips_fetch(self, monkeypatch, capsys):
+        """--offline returns 0 with the exact notice and never touches the network."""
+        from unittest.mock import MagicMock
+
+        # Any attempt to fetch would fail the test, proving the network is skipped.
+        urlopen = MagicMock(side_effect=AssertionError("network must not be used in offline mode"))
+        monkeypatch.setattr("rhiza_hooks.check_template_bundles.urlopen", urlopen)
+
+        assert main(["--offline"]) == 0
+        assert capsys.readouterr().out == "Offline mode: skipping remote template bundles validation\n"
+        urlopen.assert_not_called()

--- a/tests/test_check_workflow_names.py
+++ b/tests/test_check_workflow_names.py
@@ -180,6 +180,48 @@ jobs:
         assert "(RHIZA) BUILD & DEPLOY" in content
 
 
+class TestTopLevelVsNestedName:
+    """Regression matrix: only the top-level workflow name is touched (#161)."""
+
+    def test_job_and_step_names_are_not_rewritten(self, tmp_path: Path) -> None:
+        """Indented job/step `name:` keys are preserved; only the top-level name changes."""
+        workflow = tmp_path / "workflow.yml"
+        workflow.write_text(
+            "name: ci\non: push\njobs:\n  build:\n    name: Build Job\n    steps:\n      - name: Checkout\n"
+        )
+
+        result = check_file(str(workflow))
+
+        assert result is False
+        assert workflow.read_text() == (
+            'name: "(RHIZA) CI"\non: push\njobs:\n  build:\n    name: Build Job\n    steps:\n      - name: Checkout\n'
+        )
+
+    def test_missing_top_level_name_with_job_names(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        """A workflow with no top-level name (only job names) errors and is left untouched."""
+        workflow = tmp_path / "workflow.yml"
+        original = "on: push\njobs:\n  build:\n    name: Build Job\n    runs-on: ubuntu-latest\n"
+        workflow.write_text(original)
+
+        result = check_file(str(workflow))
+
+        assert result is False
+        assert capsys.readouterr().out == f"Error: {workflow} missing 'name' field.\n"
+        # The job-level name is not mistaken for the workflow name and the file is unchanged.
+        assert workflow.read_text() == original
+
+    def test_already_correct_with_nested_names_is_noop(self, tmp_path: Path) -> None:
+        """A correct top-level name returns True and the file is left byte-for-byte unchanged."""
+        workflow = tmp_path / "workflow.yml"
+        original = 'name: "(RHIZA) CI"\non: push\njobs:\n  build:\n    name: Build Job\n'
+        workflow.write_text(original)
+
+        result = check_file(str(workflow))
+
+        assert result is True
+        assert workflow.read_text() == original
+
+
 class TestMain:
     """Tests for main function."""
 


### PR DESCRIPTION
## Summary

Clears the remaining open issues (#161, #163, #166, #167, #168, #169, #170). All behind the repo's gates: **283 tests, 100% coverage, ruff/mypy clean, 100% mutation score** on the changed files.

### Code

- **#167 — `check-makefile-targets` customisation.** New `--target NAME` (repeatable) *replaces* the default required set; `--extend-target NAME` (repeatable) *adds* to it. Default behaviour is unchanged when neither is passed.
- **#163 — `check-template-bundles` resilience.** The remote fetch now retries once with a linear backoff on transient `URLError`/`TimeoutError` (HTTP errors like 404 stay permanent, no retry). New `--offline` flag skips the network fetch entirely and passes.
- **#161 — `check-workflow-names` hardening.** Clarified that only the column-0 top-level `name:` is rewritten (job/step names are indented and never matched), plus a regression matrix: job/step names untouched, missing top-level name alongside job names, and a no-op on already-correct files with nested names.

### Config

- **#168** — bumped the self-referenced `rhiza-hooks` rev `v0.4.0 → v0.6.2` in `.pre-commit-config.yaml` and the README Quick Start `v0.5.1 → v0.6.2`.
- **#166** — documented (in `.pre-commit-config.yaml`) why `check-template-bundles` is intentionally not enabled for local commits (network dependency; it runs in CI), with the manual/`--offline` invocations for on-demand local use.

### Docs

- **#169** — added a hook reference table to the README (hook → triggers on → autofixes? → exit-code semantics), making the warn-only vs failing/autofixing distinction explicit.
- **#170** — added a contributor section covering `make test`/`make mutation`, reading the HTML mutation report, and the equivalent-mutant `# pragma: no mutate` convention (with a worked example).

## Verification
- 270 → 283 tests, 100% branch coverage maintained
- `ruff check` + `ruff format --check` clean, `mypy --strict` clean
- `mutmut` on `check_makefile_targets.py` + `check_template_bundles.py`: 0 survivors (one genuinely-equivalent `errors` initializer marked `# pragma: no mutate`)
- README-validation suite (`.rhiza/tests/sync`) passes; illustrative pragma snippet marked `+RHIZA_SKIP`

Closes #161
Closes #163
Closes #166
Closes #167
Closes #168
Closes #169
Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)