### PR TITLE
Address #175, #177, #180: gitignore, SHA-pinned workflows, compound requires-python

### DIFF
--- a/.github/workflows/rhiza_benchmark.yml
+++ b/.github/workflows/rhiza_benchmark.yml
@@ -21,5 +21,5 @@ on:
 
 jobs:
   benchmark:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@v0.18.8
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_benchmark.yml@ae79c6f0729b21239655abe390269be9171f907d # v0.18.8
     secrets: inherit

--- a/.github/workflows/rhiza_book.yml
+++ b/.github/workflows/rhiza_book.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   book:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@v0.18.8
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_book.yml@ae79c6f0729b21239655abe390269be9171f907d # v0.18.8
     secrets: inherit
     permissions:
       contents: read

--- a/.github/workflows/rhiza_ci.yml
+++ b/.github/workflows/rhiza_ci.yml
@@ -47,5 +47,5 @@ jobs:
         run: uv lock --check
 
   ci:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@v0.18.8
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_ci.yml@ae79c6f0729b21239655abe390269be9171f907d # v0.18.8
     secrets: inherit

--- a/.github/workflows/rhiza_codeql.yml
+++ b/.github/workflows/rhiza_codeql.yml
@@ -29,5 +29,5 @@ on:
 
 jobs:
   codeql:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@v0.18.8
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_codeql.yml@ae79c6f0729b21239655abe390269be9171f907d # v0.18.8
     secrets: inherit

--- a/.github/workflows/rhiza_marimo.yml
+++ b/.github/workflows/rhiza_marimo.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   marimo:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@v0.18.8
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_marimo.yml@ae79c6f0729b21239655abe390269be9171f907d # v0.18.8
     secrets: inherit

--- a/.github/workflows/rhiza_sync.yml
+++ b/.github/workflows/rhiza_sync.yml
@@ -36,7 +36,7 @@ on:
 
 jobs:
   sync:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@v0.18.8
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_sync.yml@ae79c6f0729b21239655abe390269be9171f907d # v0.18.8
     with:
       direct: ${{ github.event_name == 'push' }}
       create-pr: ${{ github.event_name != 'push' && (github.event_name == 'schedule' || inputs.create-pr == true) }}

--- a/.github/workflows/rhiza_weekly.yml
+++ b/.github/workflows/rhiza_weekly.yml
@@ -28,5 +28,5 @@ on:
 
 jobs:
   weekly:
-    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@v0.18.8
+    uses: jebel-quant/rhiza/.github/workflows/rhiza_weekly.yml@ae79c6f0729b21239655abe390269be9171f907d # v0.18.8
     secrets: inherit

--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ coverage.json
 .benchmarks/
 .pytest_cache/
 cover/
+.mypy_cache/
 
 # Security scanning baselines (regenerate as needed)
 .bandit-baseline.json

--- a/src/rhiza_hooks/check_python_version.py
+++ b/src/rhiza_hooks/check_python_version.py
@@ -49,15 +49,45 @@ def parse_version(version_str: str) -> tuple[int, int]:
     return (int(parts[0]), int(parts[1]))
 
 
-def get_pyproject_requires_python(repo_root: Path) -> tuple[str, str] | None:
-    """Read requires-python constraint from pyproject.toml.
+def _parse_specifier(requires_python: str) -> list[tuple[str, str]]:
+    """Parse a (possibly compound) requires-python specifier into clauses.
+
+    The specifier is split on commas and the leading ``operator`` +
+    ``major.minor`` is extracted from each clause, so ``">=3.11,<3.14"`` yields
+    ``[(">=", "3.11"), ("<", "3.14")]``. A clause with no operator defaults to
+    ``"=="``. Clauses that contain no recognizable ``major.minor`` version are
+    skipped.
+
+    Note: only the ``major.minor`` of each clause is considered; patch-level and
+    wildcard parts (e.g. the ``.*`` in ``!=3.10.*``) are ignored, matching the
+    granularity of :func:`version_satisfies_constraint`.
+
+    Args:
+        requires_python: The raw ``requires-python`` string from pyproject.toml.
+
+    Returns:
+        List of (operator, version) clauses (empty if none are parseable).
+    """
+    clauses: list[tuple[str, str]] = []
+    for part in requires_python.split(","):
+        match = re.match(r"\s*([><=!~]+)?\s*(\d+\.\d+)", part)
+        if match is None:
+            continue
+        operator = match.group(1) or "=="  # Default to exact match if no operator
+        clauses.append((operator, match.group(2)))
+    return clauses
+
+
+def get_pyproject_requires_python(repo_root: Path) -> list[tuple[str, str]] | None:
+    """Read requires-python constraint(s) from pyproject.toml.
 
     Args:
         repo_root: Root directory of the repository
 
     Returns:
-        Tuple of (operator, version) or None if not specified.
-        For example: (">=", "3.11") or ("==", "3.12")
+        List of (operator, version) clauses, or None if not specified or
+        unparseable. A compound specifier yields one entry per comma-separated
+        clause, e.g. ">=3.11,<3.14" -> [(">=", "3.11"), ("<", "3.14")].
     """
     pyproject_file = repo_root / "pyproject.toml"
     if not pyproject_file.exists():
@@ -73,14 +103,9 @@ def get_pyproject_requires_python(repo_root: Path) -> tuple[str, str] | None:
     if not requires_python:
         return None
 
-    # Parse the constraint (e.g., ">=3.11", "==3.12", "~=3.11")
-    match = re.match(r"([><=!~]+)?\s*(\d+\.\d+)", requires_python.strip())
-    if not match:
-        return None
-
-    operator = match.group(1) or "=="  # Default to exact match if no operator
-    version = match.group(2)
-    return (operator, version)
+    clauses = _parse_specifier(requires_python)
+    # No clause parsed (e.g. "invalid-version"): treat as unspecified.
+    return clauses or None
 
 
 def version_satisfies_constraint(version: str, operator: str, constraint_version: str) -> bool:
@@ -135,12 +160,17 @@ def check_version_consistency(repo_root: Path) -> list[str]:
         # One or both files don't specify a version, that's okay
         return []
 
-    operator, constraint_version = requires_python
+    # Every clause of a (possibly compound) specifier must be satisfied.
+    unsatisfied = any(
+        not version_satisfies_constraint(python_version, operator, constraint_version)
+        for operator, constraint_version in requires_python
+    )
 
-    if not version_satisfies_constraint(python_version, operator, constraint_version):
+    if unsatisfied:
+        constraint_str = ",".join(f"{operator}{version}" for operator, version in requires_python)
         errors.append(
             f"Python version mismatch: .python-version has {python_version}, "
-            f"but pyproject.toml requires-python is {operator}{constraint_version}"
+            f"but pyproject.toml requires-python is {constraint_str}"
         )
 
     return errors

--- a/tests/test_check_python_version.py
+++ b/tests/test_check_python_version.py
@@ -145,28 +145,44 @@ class TestGetPyprojectRequiresPython:
     """Tests for get_pyproject_requires_python function."""
 
     def test_parses_gte_constraint(self, tmp_path: Path) -> None:
-        """Parses >=3.11 constraint."""
+        """Parses >=3.11 constraint into a single clause."""
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text('[project]\nrequires-python = ">=3.11"\n')
-        assert get_pyproject_requires_python(tmp_path) == (">=", "3.11")
+        assert get_pyproject_requires_python(tmp_path) == [(">=", "3.11")]
 
     def test_parses_eq_constraint(self, tmp_path: Path) -> None:
-        """Parses ==3.12 constraint."""
+        """Parses ==3.12 constraint into a single clause."""
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text('[project]\nrequires-python = "==3.12"\n')
-        assert get_pyproject_requires_python(tmp_path) == ("==", "3.12")
+        assert get_pyproject_requires_python(tmp_path) == [("==", "3.12")]
 
     def test_parses_compatible_release(self, tmp_path: Path) -> None:
-        """Parses ~=3.11 constraint."""
+        """Parses ~=3.11 constraint into a single clause."""
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text('[project]\nrequires-python = "~=3.11"\n')
-        assert get_pyproject_requires_python(tmp_path) == ("~=", "3.11")
+        assert get_pyproject_requires_python(tmp_path) == [("~=", "3.11")]
 
     def test_bare_version_defaults_to_equality_operator(self, tmp_path: Path) -> None:
         """A bare version with no operator defaults to '==' (pins the default literal)."""
         pyproject = tmp_path / "pyproject.toml"
         pyproject.write_text('[project]\nrequires-python = "3.11"\n')
-        assert get_pyproject_requires_python(tmp_path) == ("==", "3.11")
+        assert get_pyproject_requires_python(tmp_path) == [("==", "3.11")]
+
+    def test_parses_compound_specifier(self, tmp_path: Path) -> None:
+        """A compound specifier yields one clause per comma-separated part, in order."""
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[project]\nrequires-python = ">=3.11,<3.14"\n')
+        assert get_pyproject_requires_python(tmp_path) == [(">=", "3.11"), ("<", "3.14")]
+
+    def test_compound_specifier_skips_unparseable_clause(self, tmp_path: Path) -> None:
+        """An unparseable clause is skipped (not a stop) so a later valid clause is still kept.
+
+        The bad clause is placed *first* so this distinguishes ``continue`` (skip and
+        keep scanning) from ``break`` (abandon the rest).
+        """
+        pyproject = tmp_path / "pyproject.toml"
+        pyproject.write_text('[project]\nrequires-python = "invalid,>=3.11"\n')
+        assert get_pyproject_requires_python(tmp_path) == [(">=", "3.11")]
 
     def test_missing_file_returns_none(self, tmp_path: Path) -> None:
         """Returns None if file doesn't exist."""
@@ -232,6 +248,30 @@ class TestCheckVersionConsistency:
         errors = check_version_consistency(tmp_path)
 
         assert len(errors) == 1
+
+    def test_compound_specifier_satisfied(self, tmp_path: Path) -> None:
+        """No error when .python-version satisfies every clause of a compound specifier."""
+        (tmp_path / ".python-version").write_text("3.12\n")
+        (tmp_path / "pyproject.toml").write_text('[project]\nrequires-python = ">=3.11,<3.14"\n')
+
+        errors = check_version_consistency(tmp_path)
+
+        assert errors == []
+
+    def test_compound_specifier_upper_bound_violated(self, tmp_path: Path) -> None:
+        """Error when an upper-bound clause is violated even though the lower bound holds.
+
+        Pins the per-clause check (3.14 satisfies >=3.11 but not <3.14) and the
+        comma-joined constraint string in the message.
+        """
+        (tmp_path / ".python-version").write_text("3.14\n")
+        (tmp_path / "pyproject.toml").write_text('[project]\nrequires-python = ">=3.11,<3.14"\n')
+
+        errors = check_version_consistency(tmp_path)
+
+        assert errors == [
+            "Python version mismatch: .python-version has 3.14, but pyproject.toml requires-python is >=3.11,<3.14"
+        ]
 
     def test_no_python_version_file(self, tmp_path: Path) -> None:
         """No error when .python-version doesn't exist."""


### PR DESCRIPTION
Addresses three of the repo-hardening issues toward a 10/10 score.

## Closes
- Closes #175 — gitignore generated artifacts
- Closes #177 — SHA-pin reusable workflows
- Closes #180 — handle compound `requires-python` specifiers

## Changes

### #175 — Gitignore generated artifacts
Nothing was actually tracked; only `.mypy_cache/` was missing from `.gitignore`. Added it. `git ls-files` shows no generated/cache artifacts.

### #177 — SHA-pin reusable workflows
Resolved annotated tag `v0.18.8` → commit `ae79c6f0729b21239655abe390269be9171f907d` and pinned all 7 `jebel-quant/rhiza` reusable-workflow `uses:` references with a trailing `# v0.18.8` comment. Satisfies OpenSSF Scorecard's pinned-dependencies check. `actionlint` and `check-github-workflows` pass.

⚠️ **Caveat:** `rhiza_sync` may re-sync these workflow stubs from upstream and revert the pins. The durable fix belongs in the rhiza template repo; this PR pins them locally as an interim improvement.

### #180 — Compound `requires-python` specifiers
`get_pyproject_requires_python` now returns a list of `(operator, version)` clauses instead of a single tuple. A compound specifier such as `>=3.11,<3.14` is fully parsed, and **every** clause must be satisfied — previously the upper bound was silently ignored. Unparseable clauses are skipped.

## Verification
- 287 tests pass
- 100% line/branch coverage maintained
- 100% mutation score on `check_python_version.py` (90/90 mutants killed)
- mypy --strict, ruff, bandit, actionlint all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)