### PR TITLE
Fix: install rhiza_hooks into the book build env for mkdocstrings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,10 @@ DEFAULT_AI_MODEL=claude-sonnet-4.6
 LOGO_FILE=.rhiza/assets/rhiza-logo.svg
 GH_AW_ENGINE ?= copilot  # Default AI engine for gh-aw workflows (copilot, claude, or codex)
 
-# Override template default: include mkdocstrings plugin for API docs
-MKDOCS_EXTRA_PACKAGES = --with 'mkdocstrings[python]'
+# Override template default: include the mkdocstrings plugin for API docs and
+# install this project (src-layout `rhiza_hooks`) into the isolated book-build
+# env so `::: rhiza_hooks.*` autodoc blocks can resolve the package.
+MKDOCS_EXTRA_PACKAGES = --with 'mkdocstrings[python]' --with .
 
 # Always include the Rhiza API (template-managed)
 include .rhiza/rhiza.mk


### PR DESCRIPTION
## Problem

`make book` (the `rhiza_book` workflow) fails on `main`:

```
accessing 'rhiza_hooks' raises ModuleNotFoundError: No module named 'rhiza_hooks'
Python error: PluginError: Could not collect 'rhiza_hooks.check_workflow_names'
make: *** [.rhiza/make.d/book.mk:52: book] Error 1
```

`book.mk` builds the docs with **zensical via `uvx`** in an isolated environment. The repo's locally-owned `docs/api-reference/*.md` pages use `::: rhiza_hooks.*` mkdocstrings autodoc, but the src-layout `rhiza_hooks` package is never installed into that `uvx` env — so mkdocstrings can't import/collect it.

## Fix

Add `--with .` to `MKDOCS_EXTRA_PACKAGES` in the thin repo-owned `Makefile` (the documented book-build extension point, already used to add `mkdocstrings[python]`). This installs the project into the `uvx` env so every documented module resolves.

Scoped entirely to the locally-owned `Makefile`; no managed files touched.

## Verification

`make book` now completes:
```
Built rhiza-hooks @ file:///.../rhiza-hooks
Build started
No issues found
[SUCCESS] Book built at _book/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)