### PR TITLE
chore: add main-branch-protection ruleset

### DIFF
--- a/.github/rulesets/main-branch-protection.json
+++ b/.github/rulesets/main-branch-protection.json
@@ -1,0 +1,47 @@
+{
+  "name": "main-branch-protection",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["~DEFAULT_BRANCH"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": true,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["squash", "merge", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          { "context": "Pre-commit hooks" },
+          { "context": "validation" },
+          { "context": "Check dependencies with deptry" },
+          { "context": "docs-coverage" },
+          { "context": "Security scanning" },
+          { "context": "License compliance scan" }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_type": "RepositoryRole",
+      "actor_id": 5,
+      "bypass_mode": "always"
+    }
+  ]
+}


### PR DESCRIPTION
Copies the `main-branch-protection` ruleset from `jebel-quant/rhiza` into this repo as committed infrastructure-as-code.

The matching live ruleset is already **active** on the repository (id `18057435`); this PR commits the canonical source of truth. CLAUDE.md notes `.github/rulesets/*` is not synced by the template and must be managed separately here.

## Why
Improves the OpenSSF Scorecard **Branch-Protection** check (currently 0/10 — `main` had no protection). The admin (`RepositoryRole 5`) bypass actor preserves the solo-maintainer merge flow and direct version-bump pushes to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)