### PR TITLE
chore(fuzz): use $SRC directly and pin pip in the ClusterFuzzLite build

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -4,6 +4,6 @@
 # Pinned by SHA256 so the build image only changes through reviewed updates.
 FROM gcr.io/oss-fuzz-base/base-builder-python@sha256:99c714c91ec30778a3ce3ae5b37491a81fc043808bc8f2955159c2f608f80116
 
-COPY . $SRC/rhiza-hooks
-WORKDIR $SRC/rhiza-hooks
+COPY . $SRC
+WORKDIR $SRC
 COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -2,7 +2,11 @@
 # ClusterFuzzLite build script — installs rhiza_hooks and compiles each Python
 # harness in tests/fuzz/ via OSS-Fuzz's compile_python_fuzzer helper.
 
-cd "$SRC/rhiza-hooks"
+cd "$SRC"
+
+# Pin pip so the build environment is reproducible and only changes through a
+# reviewed bump (the same rationale as the SHA-pinned base image).
+pip3 install --upgrade "pip==24.3.1"
 
 # Install the package and its runtime dependencies (e.g. PyYAML) into the build
 # environment so PyInstaller can discover and bundle rhiza_hooks into each


### PR DESCRIPTION
Small follow-up to the fuzzing setup merged in #206.

- **Dockerfile**: `COPY`/`WORKDIR` use `$SRC` directly instead of a hardcoded `$SRC/rhiza-hooks` subdirectory.
- **build.sh**: `cd "$SRC"` (no project-name path) and pin pip to `24.3.1` for a reproducible build environment — same rationale as the SHA-pinned base image.

The fuzzing CI re-runs on this PR and will re-verify the build/run from the new layout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)