### PR TITLE
docs: document internal logic modules in the API reference

### DIFF
--- a/docs/api-reference/_bundles_config.md
+++ b/docs/api-reference/_bundles_config.md
@@ -1,0 +1,3 @@
+# _bundles_config
+
+::: rhiza_hooks._bundles_config

--- a/docs/api-reference/_bundles_fetch.md
+++ b/docs/api-reference/_bundles_fetch.md
@@ -1,0 +1,3 @@
+# _bundles_fetch
+
+::: rhiza_hooks._bundles_fetch

--- a/docs/api-reference/_bundles_validate.md
+++ b/docs/api-reference/_bundles_validate.md
@@ -1,0 +1,3 @@
+# _bundles_validate
+
+::: rhiza_hooks._bundles_validate

--- a/docs/api-reference/_repo.md
+++ b/docs/api-reference/_repo.md
@@ -1,0 +1,3 @@
+# _repo
+
+::: rhiza_hooks._repo

--- a/docs/api-reference/index.md
+++ b/docs/api-reference/index.md
@@ -1,6 +1,6 @@
 # API Reference
 
-`rhiza_hooks` ships six pre-commit hooks, each implemented as a standalone module with a `main()` entry point.
+`rhiza_hooks` ships one pre-commit hook per module, each implemented as a standalone module with a `main()` entry point.
 
 | Module | Entry point | Purpose |
 |---|---|---|
@@ -10,3 +10,14 @@
 | [`check_template_bundles`](check_template_bundles.md) | `check-template-bundles` | Validate `template-bundles.yml` structure |
 | [`check_workflow_names`](check_workflow_names.md) | `check-rhiza-workflow-names` | Enforce `(RHIZA)` prefix on GitHub Actions workflow names |
 | [`update_readme_help`](update_readme_help.md) | `update-readme-help` | Embed `make help` output into `README.md` |
+
+## Internal modules
+
+These modules hold shared logic used by the hooks above. They have no `main()` entry point and are not part of the public CLI surface, but are documented here for contributors.
+
+| Module | Purpose |
+|---|---|
+| [`_bundles_config`](_bundles_config.md) | Read the project's `.rhiza/template.yml` configuration |
+| [`_bundles_fetch`](_bundles_fetch.md) | Load/fetch a template-bundles document (local, bytes, or remote) into a typed result |
+| [`_bundles_validate`](_bundles_validate.md) | Structural validation of a template-bundles document |
+| [`_repo`](_repo.md) | Shared helpers (e.g. locating the repository root) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,11 @@ nav:
       - check_template_bundles: api-reference/check_template_bundles.md
       - check_workflow_names: api-reference/check_workflow_names.md
       - update_readme_help: api-reference/update_readme_help.md
+      - Internals:
+          - _bundles_config: api-reference/_bundles_config.md
+          - _bundles_fetch: api-reference/_bundles_fetch.md
+          - _bundles_validate: api-reference/_bundles_validate.md
+          - _repo: api-reference/_repo.md
   - Reports:
       - Test Report: reports/html-report/report.html
       - Coverage Report: reports/html-coverage/index.html


### PR DESCRIPTION
Closes #213

## What

The published API reference (`docs/api-reference/`) and the mkdocs nav covered only the six entry-point hook modules. The internal modules that hold the bulk of the validation/fetch logic were absent from the reference despite carrying full docstrings:

- `_bundles_validate` (structural validation engine)
- `_bundles_fetch` (load/fetch + retry, `BundlesDoc`)
- `_bundles_config` (reading `.rhiza/template.yml`)
- `_repo` (`find_repo_root`)

## Changes

- Add four mkdocstrings stub pages (`docs/api-reference/_*.md`).
- Add an **Internals** sub-section to the API Reference nav in `mkdocs.yml`.
- Add an "Internal modules" table to `docs/api-reference/index.md` and replace the brittle hard-coded "ships six pre-commit hooks" wording.

Docs-only; no source or behaviour change.

## Gates

- `make fmt` — PASS
- `make book` — PASS (No issues found; the four internal pages render under `_book/api-reference/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)