### PR TITLE
refactor: drop unused args binding in check_python_version main

### DIFF
--- a/src/rhiza_hooks/check_python_version.py
+++ b/src/rhiza_hooks/check_python_version.py
@@ -187,7 +187,7 @@ def main(argv: list[str] | None = None) -> int:
         nargs="*",
         help="Filenames (ignored, checks repo root)",
     )
-    args = parser.parse_args(argv)  # noqa: F841
+    parser.parse_args(argv)  # validate/consume pre-commit's filename args; result unused
 
     repo_root = find_repo_root()
     errors = check_version_consistency(repo_root)


### PR DESCRIPTION
## Summary

`main()` in `check_python_version.py` calls `parser.parse_args()` only to validate/consume the filenames that pre-commit passes on the command line — the hook itself operates on the repo root, not on individual files. The parsed result was bound to an unused `args` variable, requiring a `# noqa: F841` suppression.

This calls `parse_args()` for its side effects (argv validation, `--help`, usage errors) without binding the result, and adds a short comment explaining why the return value is unused. No `noqa` needed.

```python
parser.parse_args(argv)  # validate/consume pre-commit's filename args; result unused
```

## Test plan

- `ruff check` passes (no longer needs the suppression).
- Pre-commit hooks pass on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)