### PR TITLE
Potential fixes for 2 code quality findings

### DIFF
--- a/src/rhiza_hooks/check_python_version.py
+++ b/src/rhiza_hooks/check_python_version.py
@@ -133,7 +133,10 @@ def version_satisfies_constraint(version: str, operator: str, constraint_version
         return v <= cv
     elif operator == "<":
         return v < cv
-    elif operator == "==" or operator == "":
+    elif operator == "==":
+        return v == cv
+    elif operator == "":
+        # Bare version specifier (no explicit operator) is treated as equality.
         return v == cv
     elif operator == "!=":
         return v != cv

--- a/src/rhiza_hooks/check_python_version.py
+++ b/src/rhiza_hooks/check_python_version.py
@@ -45,7 +45,11 @@ def parse_version(version_str: str) -> tuple[int, int]:
     >>> parse_version("3.12")
     (3, 12)
     """
-    parts = version_str.split(".")
+    normalized = version_str.strip()
+    if re.fullmatch(r"\d+\.\d+", normalized) is None:
+        raise ValueError(f"Invalid version string: {version_str!r}. Expected 'major.minor'.")
+
+    parts = normalized.split(".")
     return (int(parts[0]), int(parts[1]))
 
 

--- a/src/rhiza_hooks/check_python_version.py
+++ b/src/rhiza_hooks/check_python_version.py
@@ -47,7 +47,8 @@ def parse_version(version_str: str) -> tuple[int, int]:
     """
     normalized = version_str.strip()
     if re.fullmatch(r"\d+\.\d+", normalized) is None:
-        raise ValueError(f"Invalid version string: {version_str!r}. Expected 'major.minor'.")
+        msg = f"Invalid version string: {version_str!r}. Expected 'major.minor'."
+        raise ValueError(msg)
 
     parts = normalized.split(".")
     return (int(parts[0]), int(parts[1]))

--- a/src/rhiza_hooks/check_template_bundles.py
+++ b/src/rhiza_hooks/check_template_bundles.py
@@ -30,21 +30,20 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from rhiza_hooks import _bundles_validate, _repo
 from rhiza_hooks._bundles_config import _get_config_data
 from rhiza_hooks._bundles_fetch import (
     _FETCH_ATTEMPTS,
     _FETCH_TIMEOUT_SECONDS,
     _fetch_remote_bundles,
 )
-from rhiza_hooks._bundles_validate import _validate_selected_bundles, _validate_top_level_fields
-from rhiza_hooks._repo import find_repo_root
 
 
 def _get_config_path(args: argparse.Namespace) -> Path:
     """Get the configuration file path from arguments or default location."""
     if args.filenames:
         return Path(args.filenames[0])
-    return find_repo_root() / ".rhiza" / "template.yml"
+    return _repo.find_repo_root() / ".rhiza" / "template.yml"
 
 
 def _load_and_validate_config(config_path: Path) -> tuple[dict[str, Any] | None, set[str] | None]:
@@ -93,7 +92,7 @@ def _validate_remote_bundles(
     data = fetched.data
 
     # Validate top-level structure
-    errors = _validate_top_level_fields(data)
+    errors = _bundles_validate._validate_top_level_fields(data)
     if errors:
         print("\n✗ Template bundles validation failed:")
         for error in errors:
@@ -111,7 +110,7 @@ def _validate_remote_bundles(
 
 def _validate_templates_in_bundles(templates_set: set[str], bundles: dict[Any, Any], config_path: Path) -> list[str]:
     """Validate that requested templates exist in the remote bundles and are well-formed."""
-    return _validate_selected_bundles(
+    return _bundles_validate._validate_selected_bundles(
         templates_set,
         bundles,
         lambda t: f"Template '{t}' specified in {config_path} not found in remote bundles",

--- a/src/rhiza_hooks/check_template_bundles.py
+++ b/src/rhiza_hooks/check_template_bundles.py
@@ -31,20 +31,12 @@ from pathlib import Path
 from typing import Any
 
 from rhiza_hooks._bundles_config import _get_config_data
-from rhiza_hooks._bundles_config import _get_templates_from_config as _get_templates_from_config  # re-export
 from rhiza_hooks._bundles_fetch import (
     _FETCH_ATTEMPTS,
     _FETCH_TIMEOUT_SECONDS,
     _fetch_remote_bundles,
 )
-from rhiza_hooks._bundles_fetch import BundlesDoc as BundlesDoc  # re-export
-from rhiza_hooks._bundles_fetch import _load_yaml_file as _load_yaml_file  # re-export
-from rhiza_hooks._bundles_fetch import _parse_remote_bundles as _parse_remote_bundles  # re-export
-from rhiza_hooks._bundles_validate import _validate_bundle_structure as _validate_bundle_structure  # re-export
-from rhiza_hooks._bundles_validate import _validate_examples as _validate_examples  # re-export
-from rhiza_hooks._bundles_validate import _validate_metadata as _validate_metadata  # re-export
 from rhiza_hooks._bundles_validate import _validate_selected_bundles, _validate_top_level_fields
-from rhiza_hooks._bundles_validate import validate_template_bundles as validate_template_bundles  # re-export
 from rhiza_hooks._repo import find_repo_root
 
 

--- a/tests/test_check_makefile_targets.py
+++ b/tests/test_check_makefile_targets.py
@@ -261,11 +261,15 @@ class TestModuleExecution:
     def test_module_executes_main(self) -> None:
         """Module execution calls main and exits with its return value."""
         import runpy
+        import sys
         from unittest.mock import patch
 
         with (
             patch("rhiza_hooks.check_makefile_targets.sys.argv", ["check_makefile_targets"]),
             patch("rhiza_hooks.check_makefile_targets.sys.exit") as mock_exit,
         ):
+            # Drop the pre-imported module so runpy executes a fresh copy without
+            # the "found in sys.modules ... prior to execution" RuntimeWarning.
+            sys.modules.pop("rhiza_hooks.check_makefile_targets", None)
             runpy.run_module("rhiza_hooks.check_makefile_targets", run_name="__main__")
             mock_exit.assert_called_once_with(0)

--- a/tests/test_check_makefile_targets.py
+++ b/tests/test_check_makefile_targets.py
@@ -261,15 +261,18 @@ class TestModuleExecution:
     def test_module_executes_main(self) -> None:
         """Module execution calls main and exits with its return value."""
         import runpy
-        import sys
+        import warnings
         from unittest.mock import patch
 
         with (
             patch("rhiza_hooks.check_makefile_targets.sys.argv", ["check_makefile_targets"]),
             patch("rhiza_hooks.check_makefile_targets.sys.exit") as mock_exit,
         ):
-            # Drop the pre-imported module so runpy executes a fresh copy without
-            # the "found in sys.modules ... prior to execution" RuntimeWarning.
-            sys.modules.pop("rhiza_hooks.check_makefile_targets", None)
-            runpy.run_module("rhiza_hooks.check_makefile_targets", run_name="__main__")
+            # The module is already imported (top-level test import), so runpy warns
+            # it was "found in sys.modules ... prior to execution"; filter just that
+            # warning rather than mutating sys.modules, which would break module
+            # identity for other tests that monkeypatch this module.
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", message=r".*found in sys\.modules.*", category=RuntimeWarning)
+                runpy.run_module("rhiza_hooks.check_makefile_targets", run_name="__main__")
             mock_exit.assert_called_once_with(0)

--- a/tests/test_check_python_version.py
+++ b/tests/test_check_python_version.py
@@ -422,10 +422,13 @@ class TestModuleExecution:
             patch("rhiza_hooks.check_python_version.sys.exit") as mock_exit,
         ):
             import runpy
-            import sys
+            import warnings
 
-            # Drop the pre-imported module so runpy executes a fresh copy without
-            # the "found in sys.modules ... prior to execution" RuntimeWarning.
-            sys.modules.pop("rhiza_hooks.check_python_version", None)
-            runpy.run_module("rhiza_hooks.check_python_version", run_name="__main__")
+            # The module is already imported (top-level test import), so runpy warns
+            # it was "found in sys.modules ... prior to execution"; filter just that
+            # warning rather than mutating sys.modules, which would break module
+            # identity for other tests that monkeypatch this module.
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", message=r".*found in sys\.modules.*", category=RuntimeWarning)
+                runpy.run_module("rhiza_hooks.check_python_version", run_name="__main__")
             mock_exit.assert_called_once_with(0)

--- a/tests/test_check_python_version.py
+++ b/tests/test_check_python_version.py
@@ -416,6 +416,10 @@ class TestModuleExecution:
             patch("rhiza_hooks.check_python_version.sys.exit") as mock_exit,
         ):
             import runpy
+            import sys
 
+            # Drop the pre-imported module so runpy executes a fresh copy without
+            # the "found in sys.modules ... prior to execution" RuntimeWarning.
+            sys.modules.pop("rhiza_hooks.check_python_version", None)
             runpy.run_module("rhiza_hooks.check_python_version", run_name="__main__")
             mock_exit.assert_called_once_with(0)

--- a/tests/test_check_python_version.py
+++ b/tests/test_check_python_version.py
@@ -34,6 +34,12 @@ class TestParseVersion:
         # Note: our parse_version only handles major.minor
         assert parse_version("3.11") == (3, 11)
 
+    @pytest.mark.parametrize("bad", ["", "3", "3.x", "3.11.5", "abc", "3,11"])
+    def test_parse_version_rejects_invalid(self, bad: str) -> None:
+        """Reject anything that is not exactly 'major.minor'."""
+        with pytest.raises(ValueError, match="Invalid version string"):
+            parse_version(bad)
+
 
 class TestVersionSatisfiesConstraint:
     """Tests for version_satisfies_constraint function."""

--- a/tests/test_check_rhiza_config.py
+++ b/tests/test_check_rhiza_config.py
@@ -364,11 +364,15 @@ class TestModuleExecution:
     def test_module_executes_main(self) -> None:
         """Module execution calls main and exits with its return value."""
         import runpy
+        import sys
         from unittest.mock import patch
 
         with (
             patch("rhiza_hooks.check_rhiza_config.sys.argv", ["check_rhiza_config"]),
             patch("rhiza_hooks.check_rhiza_config.sys.exit") as mock_exit,
         ):
+            # Drop the pre-imported module so runpy executes a fresh copy without
+            # the "found in sys.modules ... prior to execution" RuntimeWarning.
+            sys.modules.pop("rhiza_hooks.check_rhiza_config", None)
             runpy.run_module("rhiza_hooks.check_rhiza_config", run_name="__main__")
             mock_exit.assert_called_once_with(0)

--- a/tests/test_check_rhiza_config.py
+++ b/tests/test_check_rhiza_config.py
@@ -364,15 +364,18 @@ class TestModuleExecution:
     def test_module_executes_main(self) -> None:
         """Module execution calls main and exits with its return value."""
         import runpy
-        import sys
+        import warnings
         from unittest.mock import patch
 
         with (
             patch("rhiza_hooks.check_rhiza_config.sys.argv", ["check_rhiza_config"]),
             patch("rhiza_hooks.check_rhiza_config.sys.exit") as mock_exit,
         ):
-            # Drop the pre-imported module so runpy executes a fresh copy without
-            # the "found in sys.modules ... prior to execution" RuntimeWarning.
-            sys.modules.pop("rhiza_hooks.check_rhiza_config", None)
-            runpy.run_module("rhiza_hooks.check_rhiza_config", run_name="__main__")
+            # The module is already imported (top-level test import), so runpy warns
+            # it was "found in sys.modules ... prior to execution"; filter just that
+            # warning rather than mutating sys.modules, which would break module
+            # identity for other tests that monkeypatch this module.
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", message=r".*found in sys\.modules.*", category=RuntimeWarning)
+                runpy.run_module("rhiza_hooks.check_rhiza_config", run_name="__main__")
             mock_exit.assert_called_once_with(0)

--- a/tests/test_check_template_bundles.py
+++ b/tests/test_check_template_bundles.py
@@ -1446,6 +1446,7 @@ class TestMainNameBlock:
         """Test the __main__ block using runpy to maintain coverage."""
         import runpy
         import sys
+        import warnings
 
         # Create a temporary directory with a .rhiza/template.yml that won't trigger validation
         rhiza_dir = tmp_path / ".rhiza"
@@ -1462,11 +1463,14 @@ class TestMainNameBlock:
 
         try:
             # Run the module as __main__ using runpy - it should exit with code 0.
-            # Drop the pre-imported module so runpy executes a fresh copy without
-            # the "found in sys.modules ... prior to execution" RuntimeWarning.
-            sys.modules.pop("rhiza_hooks.check_template_bundles", None)
-            with pytest.raises(SystemExit) as exc_info:
-                runpy.run_module("rhiza_hooks.check_template_bundles", run_name="__main__")
+            # The module is already imported (top-level test import), so runpy warns
+            # it was "found in sys.modules ... prior to execution"; filter just that
+            # warning rather than mutating sys.modules, which would break module
+            # identity for other tests that monkeypatch this module.
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", message=r".*found in sys\.modules.*", category=RuntimeWarning)
+                with pytest.raises(SystemExit) as exc_info:
+                    runpy.run_module("rhiza_hooks.check_template_bundles", run_name="__main__")
             assert exc_info.value.code == 0
         finally:
             sys.argv = original_argv

--- a/tests/test_check_template_bundles.py
+++ b/tests/test_check_template_bundles.py
@@ -1460,7 +1460,10 @@ class TestMainNameBlock:
         sys.argv = ["rhiza_hooks.check_template_bundles"]
 
         try:
-            # Run the module as __main__ using runpy - it should exit with code 0
+            # Run the module as __main__ using runpy - it should exit with code 0.
+            # Drop the pre-imported module so runpy executes a fresh copy without
+            # the "found in sys.modules ... prior to execution" RuntimeWarning.
+            sys.modules.pop("rhiza_hooks.check_template_bundles", None)
             with pytest.raises(SystemExit) as exc_info:
                 runpy.run_module("rhiza_hooks.check_template_bundles", run_name="__main__")
             assert exc_info.value.code == 0

--- a/tests/test_check_template_bundles.py
+++ b/tests/test_check_template_bundles.py
@@ -7,20 +7,21 @@ from textwrap import dedent
 
 import pytest
 
-from rhiza_hooks.check_template_bundles import (
-    BundlesDoc,
-    _get_templates_from_config,
-    _load_and_validate_config,
-    _load_yaml_file,
+from rhiza_hooks._bundles_config import _get_templates_from_config
+from rhiza_hooks._bundles_fetch import BundlesDoc, _load_yaml_file
+from rhiza_hooks._bundles_validate import (
     _validate_bundle_structure,
     _validate_examples,
     _validate_metadata,
+    _validate_top_level_fields,
+    validate_template_bundles,
+)
+from rhiza_hooks._repo import find_repo_root
+from rhiza_hooks.check_template_bundles import (
+    _load_and_validate_config,
     _validate_remote_bundles,
     _validate_templates_in_bundles,
-    _validate_top_level_fields,
-    find_repo_root,
     main,
-    validate_template_bundles,
 )
 
 
@@ -831,7 +832,7 @@ class TestModuleExecution:
             import sys
             from unittest.mock import patch
 
-            from rhiza_hooks.check_template_bundles import BundlesDoc
+            from rhiza_hooks._bundles_fetch import BundlesDoc
 
             def mock_fetch_remote_bundles(repo, branch, **kwargs):
                 return BundlesDoc(

--- a/tests/test_check_workflow_names.py
+++ b/tests/test_check_workflow_names.py
@@ -267,8 +267,12 @@ class TestModuleExecution:
     def test_module_executes_main(self) -> None:
         """Module execution calls main."""
         import runpy
+        import sys
         from unittest.mock import patch
 
         with patch("rhiza_hooks.check_workflow_names.sys.argv", ["check_workflow_names"]):
-            # main() returns 0 when no files provided, doesn't call sys.exit
+            # main() returns 0 when no files provided, doesn't call sys.exit.
+            # Drop the pre-imported module so runpy executes a fresh copy without
+            # the "found in sys.modules ... prior to execution" RuntimeWarning.
+            sys.modules.pop("rhiza_hooks.check_workflow_names", None)
             runpy.run_module("rhiza_hooks.check_workflow_names", run_name="__main__")

--- a/tests/test_check_workflow_names.py
+++ b/tests/test_check_workflow_names.py
@@ -267,12 +267,17 @@ class TestModuleExecution:
     def test_module_executes_main(self) -> None:
         """Module execution calls main."""
         import runpy
-        import sys
+        import warnings
         from unittest.mock import patch
 
-        with patch("rhiza_hooks.check_workflow_names.sys.argv", ["check_workflow_names"]):
-            # main() returns 0 when no files provided, doesn't call sys.exit.
-            # Drop the pre-imported module so runpy executes a fresh copy without
-            # the "found in sys.modules ... prior to execution" RuntimeWarning.
-            sys.modules.pop("rhiza_hooks.check_workflow_names", None)
+        # main() returns 0 when no files provided, doesn't call sys.exit.
+        # The module is already imported (top-level test import), so runpy warns
+        # it was "found in sys.modules ... prior to execution"; filter just that
+        # warning rather than mutating sys.modules, which would break module
+        # identity for other tests that monkeypatch this module.
+        with (
+            patch("rhiza_hooks.check_workflow_names.sys.argv", ["check_workflow_names"]),
+            warnings.catch_warnings(),
+        ):
+            warnings.filterwarnings("ignore", message=r".*found in sys\.modules.*", category=RuntimeWarning)
             runpy.run_module("rhiza_hooks.check_workflow_names", run_name="__main__")

--- a/tests/test_update_readme_help.py
+++ b/tests/test_update_readme_help.py
@@ -218,7 +218,7 @@ class TestModuleExecution:
     def test_module_executes_main(self) -> None:
         """Module execution calls main and exits with its return value."""
         import runpy
-        import sys
+        import warnings
 
         # Patch subprocess.run to raise FileNotFoundError so get_make_help_output returns None
         # This needs to be patched at subprocess level since runpy creates a fresh module namespace
@@ -226,8 +226,11 @@ class TestModuleExecution:
             patch("subprocess.run", side_effect=FileNotFoundError()),
             patch("sys.exit") as mock_exit,
         ):
-            # Drop the pre-imported module so runpy executes a fresh copy without
-            # the "found in sys.modules ... prior to execution" RuntimeWarning.
-            sys.modules.pop("rhiza_hooks.update_readme_help", None)
-            runpy.run_module("rhiza_hooks.update_readme_help", run_name="__main__")
+            # The module is already imported (top-level test import), so runpy warns
+            # it was "found in sys.modules ... prior to execution"; filter just that
+            # warning rather than mutating sys.modules, which would break module
+            # identity for other tests that monkeypatch this module.
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", message=r".*found in sys\.modules.*", category=RuntimeWarning)
+                runpy.run_module("rhiza_hooks.update_readme_help", run_name="__main__")
             mock_exit.assert_called_once_with(0)

--- a/tests/test_update_readme_help.py
+++ b/tests/test_update_readme_help.py
@@ -218,6 +218,7 @@ class TestModuleExecution:
     def test_module_executes_main(self) -> None:
         """Module execution calls main and exits with its return value."""
         import runpy
+        import sys
 
         # Patch subprocess.run to raise FileNotFoundError so get_make_help_output returns None
         # This needs to be patched at subprocess level since runpy creates a fresh module namespace
@@ -225,5 +226,8 @@ class TestModuleExecution:
             patch("subprocess.run", side_effect=FileNotFoundError()),
             patch("sys.exit") as mock_exit,
         ):
+            # Drop the pre-imported module so runpy executes a fresh copy without
+            # the "found in sys.modules ... prior to execution" RuntimeWarning.
+            sys.modules.pop("rhiza_hooks.update_readme_help", None)
             runpy.run_module("rhiza_hooks.update_readme_help", run_name="__main__")
             mock_exit.assert_called_once_with(0)


### PR DESCRIPTION
_This PR applies 2/2 suggestions from code quality [AI findings](https://github.com/Jebel-Quant/rhiza-hooks/security/quality/ai-findings)._

---

**Also merged in #222** (now closed): silence the 6 runpy `RuntimeWarning`s in the `__main__`-coverage tests, plus a test covering the new `parse_version` validation. `make test` → 321 passed, 0 warnings, 100% coverage.

Closes #219
