### PR TITLE
test: silence runpy RuntimeWarnings in __main__-coverage tests

### DIFF
--- a/tests/test_check_makefile_targets.py
+++ b/tests/test_check_makefile_targets.py
@@ -261,11 +261,15 @@ class TestModuleExecution:
     def test_module_executes_main(self) -> None:
         """Module execution calls main and exits with its return value."""
         import runpy
+        import sys
         from unittest.mock import patch
 
         with (
             patch("rhiza_hooks.check_makefile_targets.sys.argv", ["check_makefile_targets"]),
             patch("rhiza_hooks.check_makefile_targets.sys.exit") as mock_exit,
         ):
+            # Drop the pre-imported module so runpy executes a fresh copy without
+            # the "found in sys.modules ... prior to execution" RuntimeWarning.
+            sys.modules.pop("rhiza_hooks.check_makefile_targets", None)
             runpy.run_module("rhiza_hooks.check_makefile_targets", run_name="__main__")
             mock_exit.assert_called_once_with(0)

--- a/tests/test_check_python_version.py
+++ b/tests/test_check_python_version.py
@@ -416,6 +416,10 @@ class TestModuleExecution:
             patch("rhiza_hooks.check_python_version.sys.exit") as mock_exit,
         ):
             import runpy
+            import sys
 
+            # Drop the pre-imported module so runpy executes a fresh copy without
+            # the "found in sys.modules ... prior to execution" RuntimeWarning.
+            sys.modules.pop("rhiza_hooks.check_python_version", None)
             runpy.run_module("rhiza_hooks.check_python_version", run_name="__main__")
             mock_exit.assert_called_once_with(0)

--- a/tests/test_check_rhiza_config.py
+++ b/tests/test_check_rhiza_config.py
@@ -364,11 +364,15 @@ class TestModuleExecution:
     def test_module_executes_main(self) -> None:
         """Module execution calls main and exits with its return value."""
         import runpy
+        import sys
         from unittest.mock import patch
 
         with (
             patch("rhiza_hooks.check_rhiza_config.sys.argv", ["check_rhiza_config"]),
             patch("rhiza_hooks.check_rhiza_config.sys.exit") as mock_exit,
         ):
+            # Drop the pre-imported module so runpy executes a fresh copy without
+            # the "found in sys.modules ... prior to execution" RuntimeWarning.
+            sys.modules.pop("rhiza_hooks.check_rhiza_config", None)
             runpy.run_module("rhiza_hooks.check_rhiza_config", run_name="__main__")
             mock_exit.assert_called_once_with(0)

--- a/tests/test_check_template_bundles.py
+++ b/tests/test_check_template_bundles.py
@@ -1460,7 +1460,10 @@ class TestMainNameBlock:
         sys.argv = ["rhiza_hooks.check_template_bundles"]
 
         try:
-            # Run the module as __main__ using runpy - it should exit with code 0
+            # Run the module as __main__ using runpy - it should exit with code 0.
+            # Drop the pre-imported module so runpy executes a fresh copy without
+            # the "found in sys.modules ... prior to execution" RuntimeWarning.
+            sys.modules.pop("rhiza_hooks.check_template_bundles", None)
             with pytest.raises(SystemExit) as exc_info:
                 runpy.run_module("rhiza_hooks.check_template_bundles", run_name="__main__")
             assert exc_info.value.code == 0

--- a/tests/test_check_workflow_names.py
+++ b/tests/test_check_workflow_names.py
@@ -267,8 +267,12 @@ class TestModuleExecution:
     def test_module_executes_main(self) -> None:
         """Module execution calls main."""
         import runpy
+        import sys
         from unittest.mock import patch
 
         with patch("rhiza_hooks.check_workflow_names.sys.argv", ["check_workflow_names"]):
-            # main() returns 0 when no files provided, doesn't call sys.exit
+            # main() returns 0 when no files provided, doesn't call sys.exit.
+            # Drop the pre-imported module so runpy executes a fresh copy without
+            # the "found in sys.modules ... prior to execution" RuntimeWarning.
+            sys.modules.pop("rhiza_hooks.check_workflow_names", None)
             runpy.run_module("rhiza_hooks.check_workflow_names", run_name="__main__")

--- a/tests/test_update_readme_help.py
+++ b/tests/test_update_readme_help.py
@@ -218,6 +218,7 @@ class TestModuleExecution:
     def test_module_executes_main(self) -> None:
         """Module execution calls main and exits with its return value."""
         import runpy
+        import sys
 
         # Patch subprocess.run to raise FileNotFoundError so get_make_help_output returns None
         # This needs to be patched at subprocess level since runpy creates a fresh module namespace
@@ -225,5 +226,8 @@ class TestModuleExecution:
             patch("subprocess.run", side_effect=FileNotFoundError()),
             patch("sys.exit") as mock_exit,
         ):
+            # Drop the pre-imported module so runpy executes a fresh copy without
+            # the "found in sys.modules ... prior to execution" RuntimeWarning.
+            sys.modules.pop("rhiza_hooks.update_readme_help", None)
             runpy.run_module("rhiza_hooks.update_readme_help", run_name="__main__")
             mock_exit.assert_called_once_with(0)


### PR DESCRIPTION
## Summary
Fixes the 6 `RuntimeWarning`s emitted during `make test` (surfaced in the v1.0.1 quality assessment, scorecard finding for Test coverage & depth).

The `TestModuleExecution` / `TestMainNameBlock` tests cover each hook's `if __name__ == "__main__":` block by re-running the module via `runpy.run_module(..., run_name="__main__")`. Because the test file already imported the module, runpy warned:

```
<frozen runpy>:128: RuntimeWarning: 'rhiza_hooks.check_python_version' found in sys.modules after import of package 'rhiza_hooks', but prior to execution of 'rhiza_hooks.check_python_version'; this may result in unpredictable behaviour
```

Fix: pop the module from `sys.modules` immediately before `run_module` so runpy executes a fresh copy — root-cause fix, not warning suppression.

## Files
- `tests/test_check_makefile_targets.py`
- `tests/test_check_python_version.py`
- `tests/test_check_rhiza_config.py`
- `tests/test_check_template_bundles.py`
- `tests/test_check_workflow_names.py`
- `tests/test_update_readme_help.py`

## Verification
`make test` → **315 passed, 0 warnings** (was `315 passed, 6 warnings`), **100.00% coverage** retained on `src/`. `make fmt` clean.

Closes #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)