### PR TITLE
test: hoist subprocess import and justify subprocess.run calls

### DIFF
--- a/tests/test_check_template_bundles.py
+++ b/tests/test_check_template_bundles.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import subprocess  # nosec B404
 from pathlib import Path
 from textwrap import dedent
 
@@ -809,7 +810,6 @@ class TestModuleExecution:
 
     def test_module_executes_main(self, tmp_path, monkeypatch):
         """Test that the module can be executed directly."""
-        import subprocess  # nosec B404
         import sys
 
         # Create a valid template.yml with templates field
@@ -857,7 +857,9 @@ class TestModuleExecution:
         # Change to the tmp_path directory
         monkeypatch.chdir(tmp_path)
 
-        # Execute the mock script
+        # Execute the mock script.
+        # Safe: sys.executable is the running interpreter and mock_script is a
+        # file created above under pytest's tmp_path — no external/user input.
         result = subprocess.run(  # nosec B603
             [sys.executable, str(mock_script)],
             capture_output=True,
@@ -1423,7 +1425,6 @@ class TestMainNameBlock:
 
     def test_main_name_block_execution(self, tmp_path):
         """Test that the module can be run as __main__."""
-        import subprocess  # nosec B404
         import sys
 
         # Create a temporary directory with a .rhiza/template.yml that won't trigger validation
@@ -1432,7 +1433,9 @@ class TestMainNameBlock:
         template_file = rhiza_dir / "template.yml"
         template_file.write_text("# No templates field")
 
-        # Run the module as __main__ using python -m
+        # Run the module as __main__ using python -m.
+        # Safe: sys.executable is the running interpreter and the argument list is
+        # a fixed module name — no external/user input.
         result = subprocess.run(  # nosec B603
             [sys.executable, "-m", "rhiza_hooks.check_template_bundles"],
             cwd=tmp_path,


### PR DESCRIPTION
## Summary
Resolves the same two code-quality (ai-findings) alerts in `tests/test_check_template_bundles.py` that **#223** targeted, but done correctly — #223's autofix placed `import subprocess` in the third-party import group, which fails ruff isort / the pre-commit gate (its CI was 10 jobs red).

## Changes
- Hoist the duplicated function-local `import subprocess  # nosec B404` (in `test_module_executes_main` and `test_main_name_block_execution`) to a single, correctly-ordered module-level import (stdlib group, alphabetical between `pathlib` and `textwrap`).
- Add a justification comment at each `subprocess.run(...)  # nosec B603` call: the command runs the current interpreter (`sys.executable`) on a fixed, non-user argument list under pytest's `tmp_path`.

## Verification
`make fmt` (incl. ruff + bandit) and `make test` green locally — **321 passed, 100% coverage**.

Supersedes #223.