### PR TITLE
fix(test): restore module-execution test broken by Copilot autofix (#227)

### DIFF
--- a/tests/test_update_readme_help.py
+++ b/tests/test_update_readme_help.py
@@ -220,9 +220,14 @@ class TestModuleExecution:
         import runpy
         import warnings
 
-        # Patch module main directly and verify module execution delegates to it.
+        # runpy executes the module in a *fresh* namespace, so the module-level
+        # `main`/`get_make_help_output` references are redefined and cannot be
+        # patched here — only globals from other modules (subprocess, sys) survive.
+        # Patch subprocess.run to raise FileNotFoundError so get_make_help_output
+        # returns None and main() returns 0; asserting sys.exit(0) proves the
+        # __main__ block ran main and threaded its return value into sys.exit.
         with (
-            patch("rhiza_hooks.update_readme_help.main", return_value=0) as mock_main,
+            patch("subprocess.run", side_effect=FileNotFoundError()),
             patch("sys.exit") as mock_exit,
         ):
             # The module is already imported (top-level test import), so runpy warns
@@ -232,5 +237,4 @@ class TestModuleExecution:
             with warnings.catch_warnings():
                 warnings.filterwarnings("ignore", message=r".*found in sys\.modules.*", category=RuntimeWarning)
                 runpy.run_module("rhiza_hooks.update_readme_help", run_name="__main__")
-            mock_main.assert_called_once_with([])
             mock_exit.assert_called_once_with(0)


### PR DESCRIPTION
## Problem

`main` (CI) and BOOK workflows are **red** on `main`.

Both fail on the same test, `tests/test_update_readme_help.py::TestModuleExecution::test_module_executes_main`:

```
AssertionError: Expected 'main' to be called once. Called 0 times.
```

(The BOOK workflow runs `make test` as a prerequisite, so it fails for the identical reason.)

## Root cause

The Copilot autofix merged in #227 rewrote the test to patch `rhiza_hooks.update_readme_help.main` directly:

```python
patch("rhiza_hooks.update_readme_help.main", return_value=0) as mock_main
...
runpy.run_module("rhiza_hooks.update_readme_help", run_name="__main__")
mock_main.assert_called_once_with([])
```

But `runpy.run_module(..., run_name="__main__")` executes the module in a **fresh namespace**, where `main` is redefined — so the patch on the *already-imported* module never applies and the freshly-run `__main__` calls the real `main`. It also asserts `main([])` while the source's `__main__` guard calls `main()` with no args. The test could never pass.

## Fix

Restore the original, correct approach. Only globals from *other* modules (`subprocess`, `sys`) survive runpy's fresh namespace, so:

- patch `subprocess.run` to raise `FileNotFoundError` → `get_make_help_output()` returns `None` → `main()` returns `0`
- patch `sys.exit` and assert it was called once with `0`

This proves the `__main__` block ran `main` and threaded its return value into `sys.exit`. Added a comment explaining why `main` cannot be patched here.

## Verification

```
321 passed   # full suite, was 1 failed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)