### PR TITLE
Consolidate AI code-quality findings (#231–#235)

### DIFF
--- a/src/rhiza_hooks/check_python_version.py
+++ b/src/rhiza_hooks/check_python_version.py
@@ -140,10 +140,9 @@ def version_satisfies_constraint(version: str, operator: str, constraint_version
         return v <= cv
     elif operator == "<":
         return v < cv
-    elif operator == "==":
-        return v == cv
-    elif operator == "":
-        # Bare version specifier (no explicit operator) is treated as equality.
+    elif operator in ("==", ""):
+        # A bare version specifier (no explicit operator) is treated as equality,
+        # matching `_parse_specifier`, which normalizes a missing operator to "==".
         return v == cv
     elif operator == "!=":
         return v != cv

--- a/src/rhiza_hooks/check_workflow_names.py
+++ b/src/rhiza_hooks/check_workflow_names.py
@@ -100,5 +100,5 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-if __name__ == "__main__":
-    main()
+if __name__ == "__main__":  # pragma: no mutate
+    sys.exit(main())

--- a/tests/test_check_template_bundles.py
+++ b/tests/test_check_template_bundles.py
@@ -874,13 +874,16 @@ class TestFetchRemoteBundles:
 
     def test_fetch_remote_bundles_http_404(self, monkeypatch):
         """Test fetching remote bundles returns 404 error."""
+        from http.client import HTTPMessage
+        from io import BytesIO
         from urllib.error import HTTPError
 
         from rhiza_hooks.check_template_bundles import _fetch_remote_bundles
 
         def mock_urlopen(url, timeout):
             """Raise an HTTP 404 error in place of opening the URL."""
-            raise HTTPError(url, 404, "Not Found", {}, None)
+            headers = HTTPMessage()
+            raise HTTPError(url, 404, "Not Found", headers, BytesIO(b""))
 
         monkeypatch.setattr("rhiza_hooks._bundles_fetch.urlopen", mock_urlopen)
 
@@ -890,13 +893,16 @@ class TestFetchRemoteBundles:
 
     def test_fetch_remote_bundles_http_error_non_404(self, monkeypatch):
         """Test fetching remote bundles with non-404 HTTP error."""
+        from http.client import HTTPMessage
+        from io import BytesIO
         from urllib.error import HTTPError
 
         from rhiza_hooks.check_template_bundles import _fetch_remote_bundles
 
         def mock_urlopen(url, timeout):
             """Raise an HTTP 500 error in place of opening the URL."""
-            raise HTTPError(url, 500, "Internal Server Error", {}, None)
+            headers = HTTPMessage()
+            raise HTTPError(url, 500, "Internal Server Error", headers, BytesIO(b""))
 
         monkeypatch.setattr("rhiza_hooks._bundles_fetch.urlopen", mock_urlopen)
 
@@ -1601,7 +1607,9 @@ class TestMainExtraCoverage:
             main(["--help"])
         assert exc_info.value.code == 0
         out = capsys.readouterr().out
-        assert "XX" not in out  # no mutated literal survived into the rendered help
+        assert (
+            "XX" not in out
+        )  # mutation-test sentinel: catches mutated argparse description/help literals leaking into --help output
         assert "Validate template-bundles.yml from remote template repository" in out
         assert "Filenames to check (should be .rhiza/template.yml)" in out
 

--- a/tests/test_check_workflow_names.py
+++ b/tests/test_check_workflow_names.py
@@ -48,7 +48,7 @@ class TestCheckFile:
     def test_invalid_yaml_returns_false(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
         """Invalid YAML returns False with the exact error prefix (no mutated wrapper)."""
         workflow = tmp_path / "workflow.yml"
-        workflow.write_text("name: test\n  invalid: yaml: syntax:\n")
+        workflow.write_text('name: "unterminated\non: push\n')
 
         result = check_file(str(workflow))
 
@@ -265,16 +265,21 @@ class TestModuleExecution:
     """Tests for module execution via if __name__ == '__main__'."""
 
     def test_module_executes_main(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Module execution calls main."""
+        """Module execution calls main and threads its return value into sys.exit."""
         import runpy
         import warnings
+        from unittest.mock import patch
 
-        # main() returns 0 when no files provided, doesn't call sys.exit.
-        # The module is already imported (top-level test import), so runpy warns
-        # it was "found in sys.modules ... prior to execution"; filter just that
-        # warning rather than mutating sys.modules, which would break module
-        # identity for other tests that monkeypatch this module.
+        # main() returns 0 when no files are provided; the __main__ block threads
+        # that into sys.exit. Patch sys.exit so runpy returns instead of raising
+        # SystemExit, then assert the exit code propagated unchanged.
         monkeypatch.setattr("sys.argv", ["check_workflow_names"])
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message=r".*found in sys\.modules.*", category=RuntimeWarning)
-            runpy.run_module("rhiza_hooks.check_workflow_names", run_name="__main__")
+        with patch("sys.exit") as mock_exit:
+            # The module is already imported (top-level test import), so runpy warns
+            # it was "found in sys.modules ... prior to execution"; filter just that
+            # warning rather than mutating sys.modules, which would break module
+            # identity for other tests that monkeypatch this module.
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", message=r".*found in sys\.modules.*", category=RuntimeWarning)
+                runpy.run_module("rhiza_hooks.check_workflow_names", run_name="__main__")
+            mock_exit.assert_called_once_with(0)

--- a/tests/test_update_readme_help.py
+++ b/tests/test_update_readme_help.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import runpy
 import subprocess  # nosec B404
+import warnings
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -217,9 +219,6 @@ class TestModuleExecution:
 
     def test_module_executes_main(self) -> None:
         """Module execution calls main and exits with its return value."""
-        import runpy
-        import warnings
-
         # runpy executes the module in a *fresh* namespace, so the module-level
         # `main`/`get_make_help_output` references are redefined and cannot be
         # patched here — only globals from other modules (subprocess, sys) survive.


### PR DESCRIPTION
Consolidates the open Copilot Autofix draft PRs into a single change. Two of them were broken against `main`; this PR applies the *intent* of those findings correctly instead of the broken literal patch.

> Note: #232 (the `check_template_bundles.py` pragma-comment clarification) was merged to `main` independently while this was being prepared, so it is not part of this diff.

## What changed, per source PR

| PR | Finding | Resolution |
|----|---------|------------|
| #231 | `check_python_version.py`: bare-operator branch duplicates the `==` branch | **Corrected.** The autofix *deleted* the `""` branch, which routes `""` to the permissive `else: return True` and breaks `test_empty_operator_unequal_is_false` (which pins the documented "empty operator means equality" contract). Instead, merge into `elif operator in ("==", "")` — removes the duplicate body, zero behavior change, all tests stay green. |
| #233 | `test_check_template_bundles.py`: `HTTPError` built with `{}`/`None` | Applied — now uses a real `HTTPMessage` + `BytesIO(b"")` body; plus the `--help` mutation-sentinel comment clarification. |
| #234 | `test_check_workflow_names.py`: weak invalid-YAML fixture + module-exec test asserts nothing | **Partly corrected.** Stronger invalid-YAML fixture applied. The autofix's `module_globals["exit_code"]` assert referenced a global the module never defined (would `KeyError`); instead I threaded `sys.exit(main())` in the `__main__` block — matching its sibling `update_readme_help.py` — and assert the exit code propagates via a patched `sys.exit`. |
| #235 | `test_update_readme_help.py`: function-local `runpy`/`warnings` imports | Applied — hoisted to top-level imports. |

## Verification

- `pytest`: 321 passed
- `ruff check` + `ruff format --check`: clean
- `ty` + `mypy` (strict): clean

Closes #231, closes #233, closes #234, closes #235. (#232 already merged.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)