### PR TITLE
fix: return None sentinel from _load_and_validate_config (supersedes #237)

### DIFF
--- a/src/rhiza_hooks/check_template_bundles.py
+++ b/src/rhiza_hooks/check_template_bundles.py
@@ -46,21 +46,21 @@ def _get_config_path(args: argparse.Namespace) -> Path:
     return _repo.find_repo_root() / ".rhiza" / "template.yml"
 
 
-def _load_and_validate_config(config_path: Path) -> tuple[dict[str, Any] | None, set[str] | None]:
+def _load_and_validate_config(config_path: Path) -> tuple[dict[str, Any], set[str]] | None:
     """Load and validate configuration file.
 
     Returns:
-        Tuple of (config, templates_set) or (None, None) if validation fails
+        (config, templates_set) if validation succeeds, otherwise ``None``
     """
     config = _get_config_data(config_path)
     if config is None:
         print(f"Could not load configuration from {config_path}, skipping validation")
-        return None, None
+        return None
 
     templates_to_check = config.get("templates")
     if templates_to_check is None or not isinstance(templates_to_check, list):
         print(f"No templates field in {config_path}, skipping bundle validation")
-        return None, None
+        return None
 
     templates_set: set[str] = {str(t) for t in templates_to_check}
     return config, templates_set
@@ -158,15 +158,12 @@ def main(argv: list[str] | None = None) -> int:
     # Get configuration path
     config_path = _get_config_path(args)
 
-    # Load and validate configuration
-    config, templates_set = _load_and_validate_config(config_path)
-    # _load_and_validate_config returns these values in lockstep:
-    #   - success path: (config_dict, templates_set)  -> both are not None
-    #   - early-exit path: (None, None)               -> both are None
-    # Therefore `config is None` and `templates_set is None` are equivalent here.
-    # Under this invariant, mutating `or` to `and` does not change behavior.
-    if config is None or templates_set is None:  # pragma: no mutate
+    # Load and validate configuration. A None result means validation was
+    # skipped (missing config or no templates field); both cases pass.
+    result = _load_and_validate_config(config_path)
+    if result is None:
         return 0
+    config, templates_set = result
 
     # Get template repository and branch
     template_repo = config.get("template-repository")

--- a/tests/test_check_template_bundles.py
+++ b/tests/test_check_template_bundles.py
@@ -1562,21 +1562,18 @@ class TestLoadAndValidateConfig:
     """Tests for _load_and_validate_config."""
 
     def test_missing_config_prints_and_returns_none(self, tmp_path, capsys):
-        """A missing config file prints the exact skip message and returns (None, None)."""
+        """A missing config file prints the exact skip message and returns None."""
         missing = tmp_path / "template.yml"
-        config, templates = _load_and_validate_config(missing)
-        assert config is None
-        assert templates is None
+        result = _load_and_validate_config(missing)
+        assert result is None
         assert capsys.readouterr().out == f"Could not load configuration from {missing}, skipping validation\n"
 
     def test_templates_not_list_returns_none(self, tmp_path, capsys):
-        """A non-list 'templates' field skips validation (pins the `or` in the guard)."""
+        """A non-list 'templates' field skips validation (returns None)."""
         cfg = tmp_path / "template.yml"
         cfg.write_text('template-repository: test/repo\ntemplate-branch: main\ntemplates: "not a list"\n')
-        config, templates = _load_and_validate_config(cfg)
-        # With `and` instead of `or`, this would fall through and return (config, set(...)).
-        assert config is None
-        assert templates is None
+        result = _load_and_validate_config(cfg)
+        assert result is None
         assert capsys.readouterr().out == f"No templates field in {cfg}, skipping bundle validation\n"
 
 


### PR DESCRIPTION
## Problem

The AI autofix in #237 changed `_load_and_validate_config` to return a bare
`None` on the skip-validation paths, but **left the tuple-unpacking call sites
intact**:

```python
config, templates_set = _load_and_validate_config(config_path)  # crashes if None
```

Unpacking `None` into two names raises `TypeError: cannot unpack non-iterable
NoneType object`. As written, #237 would crash `main()`'s early-exit path and
break three tests:

- `TestMain::test_main_skips_validation_without_templates_field`
- `TestLoadAndValidateConfig::test_missing_config_prints_and_returns_none`
- `TestLoadAndValidateConfig::test_templates_not_list_returns_none`

## Fix

This lands the intended refactor **correctly**:

- `_load_and_validate_config` returns `tuple[dict[str, Any], set[str]] | None`
- `main()` guards on `result is None` **before** unpacking, removing the
  awkward lockstep comment and the `or`-vs-`and` mutation pragma
- the two direct unit tests assert on the single `None` result

## Verification

- `pytest` — 321 passed
- `ruff check` — clean
- `mypy` — no issues

Supersedes #237 (which should be closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)